### PR TITLE
Fix iOS zero listener warning bug

### DIFF
--- a/appcenter-crashes/ios/AppCenterReactNativeCrashes/AppCenterReactNativeCrashesDelegate.m
+++ b/appcenter-crashes/ios/AppCenterReactNativeCrashes/AppCenterReactNativeCrashesDelegate.m
@@ -5,26 +5,45 @@ static NSString *ON_BEFORE_SENDING_EVENT = @"AppCenterErrorReportOnBeforeSending
 static NSString *ON_SENDING_FAILED_EVENT = @"AppCenterErrorReportOnSendingFailed";
 static NSString *ON_SENDING_SUCCEEDED_EVENT = @"AppCenterErrorReportOnSendingSucceeded";
 
-@implementation AppCenterReactNativeCrashesDelegate
+@implementation AppCenterReactNativeCrashesDelegate 
+{
+    bool hasListeners;
+}
 
 - (NSArray<NSString *> *)supportedEvents
 {
     return @[ON_BEFORE_SENDING_EVENT, ON_SENDING_FAILED_EVENT, ON_SENDING_SUCCEEDED_EVENT];
 }
 
-- (void) crashes:(MSCrashes *)crashes willSendErrorReport:(MSErrorReport *)errorReport
-{
-    [self.eventEmitter sendEventWithName:ON_BEFORE_SENDING_EVENT body:convertReportToJS(errorReport)];
+- (void)startObserving {
+    // Will be called when this module's first listener is added.
+    hasListeners = YES;
 }
 
-- (void) crashes:(MSCrashes *)crashes didSucceedSendingErrorReport:(MSErrorReport *)errorReport
-{
-    [self.eventEmitter sendEventWithName:ON_SENDING_SUCCEEDED_EVENT body:convertReportToJS(errorReport)];
+- (void)stopObserving {
+    // Will be called when this module's last listener is removed, or on dealloc.
+    hasListeners = NO;
 }
 
-- (void) crashes:(MSCrashes *)crashes didFailSendingErrorReport:(MSErrorReport *)errorReport withError:(NSError *)sendError
+- (void)crashes:(MSCrashes *)crashes willSendErrorReport:(MSErrorReport *)errorReport
 {
-    [self.eventEmitter sendEventWithName:ON_SENDING_FAILED_EVENT body:convertReportToJS(errorReport)];
+    if (hasListeners) {
+        [self.eventEmitter sendEventWithName:ON_BEFORE_SENDING_EVENT body:convertReportToJS(errorReport)];
+    }
+}
+
+- (void)crashes:(MSCrashes *)crashes didSucceedSendingErrorReport:(MSErrorReport *)errorReport
+{
+    if (hasListeners) {
+        [self.eventEmitter sendEventWithName:ON_SENDING_SUCCEEDED_EVENT body:convertReportToJS(errorReport)];
+    }
+}
+
+- (void)crashes:(MSCrashes *)crashes didFailSendingErrorReport:(MSErrorReport *)errorReport withError:(NSError *)sendError
+{
+    if (hasListeners) {
+        [self.eventEmitter sendEventWithName:ON_SENDING_FAILED_EVENT body:convertReportToJS(errorReport)];
+    }
 }
 
 @end

--- a/appcenter-push/ios/AppCenterReactNativePush/AppCenterReactNativePushDelegate.m
+++ b/appcenter-push/ios/AppCenterReactNativePush/AppCenterReactNativePushDelegate.m
@@ -13,6 +13,9 @@
 static NSString *ON_PUSH_NOTIFICATION_RECEIVED_EVENT = @"AppCenterPushNotificationReceived";
 
 @implementation AppCenterReactNativePushDelegateBase
+{
+    bool hasListeners;
+}
 
 - (instancetype) init
 {
@@ -26,20 +29,20 @@ static NSString *ON_PUSH_NOTIFICATION_RECEIVED_EVENT = @"AppCenterPushNotificati
     // This handles the scenario that when the user taps on a background notification to launch the app, the launch notification
     // gets sent to this native callback before the JS callback has a chance to register. So we need to save that notification off,
     // then send it when the JS callback regsters & stop saving notifications after
-    if (self.saveInitialNotification) {
-        if (self.initialNotification == nil) {
-            self.initialNotification = convertNotificationToJS(pushNotification);
-        }
+    if (self.saveInitialNotification && self.initialNotification == nil) {
+        self.initialNotification = convertNotificationToJS(pushNotification);
     }
-    else {
+    else if (hasListeners) {
         [self.eventEmitter sendEventWithName:ON_PUSH_NOTIFICATION_RECEIVED_EVENT body:convertNotificationToJS(pushNotification)];
     }
 }   
 
-- (void) sendAndClearInitialNotification
+- (void)sendAndClearInitialNotification
 {
     if (self.initialNotification) {
-        [self.eventEmitter sendEventWithName:ON_PUSH_NOTIFICATION_RECEIVED_EVENT body:self.initialNotification];
+        if (hasListeners) {
+            [self.eventEmitter sendEventWithName:ON_PUSH_NOTIFICATION_RECEIVED_EVENT body:self.initialNotification];
+        }
         self.initialNotification = nil;
     }
     self.saveInitialNotification = false;
@@ -48,6 +51,16 @@ static NSString *ON_PUSH_NOTIFICATION_RECEIVED_EVENT = @"AppCenterPushNotificati
 - (NSArray<NSString *> *)supportedEvents
 {
     return @[ON_PUSH_NOTIFICATION_RECEIVED_EVENT];
+}
+
+- (void)startObserving {
+    // Will be called when this module's first listener is added.
+    hasListeners = YES;
+}
+
+- (void)stopObserving {
+    // Will be called when this module's last listener is removed, or on dealloc.
+    hasListeners = NO;
 }
 
 @end


### PR DESCRIPTION
Fixing #168 

Per React Native doc, (in debug build) user will receive [a warning when emitting an event while there are no listeners registered](https://github.com/facebook/react-native/blob/v0.51.0-rc.2/React/Modules/RCTEventEmitter.m#L54). To avoid this warning, we should only emit an event when there are listeners registered. 

Please refer to react native doc (https://github.com/facebook/react-native/blob/260e6d23554a8e7f1743263894c9ca9a0cfbf01e/docs/native-modules-ios.md#optimizing-for-zero-listeners) for more information.