### PR TITLE
Fix `unabled to read license file` warning of AppCenterReactNativeShared

### DIFF
--- a/AppCenterReactNativeShared/Products/AppCenterReactNativeShared.podspec
+++ b/AppCenterReactNativeShared/Products/AppCenterReactNativeShared.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name              = 'AppCenterReactNativeShared'
   s.version           = '1.0.1'
   s.summary           = 'React Native plugin for Visual Studio App Center'
-  s.license           = { :type => 'MIT',  :file => 'AppCenterReactNativeShared/LICENSE' }
+  s.license           = { :type => 'MIT',  :file => 'AppCenterReactNativeShared/LICENSE.md' }
   s.homepage          = 'https://github.com/Microsoft/AppCenter-SDK-React-Native'
   s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/"
 

--- a/AppCenterReactNativeShared/zip-framework.sh
+++ b/AppCenterReactNativeShared/zip-framework.sh
@@ -8,6 +8,6 @@ if [ -f $zipfilename ] ; then
     rm $zipfilename
     echo "  removed old zip"
 fi
-cp ../../LICENSE AppCenterReactNativeShared
+cp ../LICENSE.md AppCenterReactNativeShared
 zip -r $zipfilename AppCenterReactNativeShared
 echo "output is here: Products/$zipfilename"


### PR DESCRIPTION
`LICENSE.md` file is missing in the `AppCenterReactNativeShared` pod, which caused a warning during `pod install` and `react-native link`.

> [!] Unable to read the license file `/Users/dihei/Code/mobile-center-sdk-react-native/AppCenterReactNativeShared/Products/AppCenterReactNativeShared/LICENSE` for the spec `AppCenterReactNativeShared (1.0.1)`