### PR TITLE
Support linking brownfield apps

### DIFF
--- a/TestApp/ios/BrownfieldPodfileExample
+++ b/TestApp/ios/BrownfieldPodfileExample
@@ -1,6 +1,7 @@
 # Example Podfile for brownfield react native application
 # For more information about using `react-native link` install pods for brownfield application, 
 # please refer to https://github.com/facebook/react-native/commit/74146cb3158273921b768c97f229695e680ea82d
+# Note that this scenario is only supported in react-native v0.50.0 or later (https://github.com/facebook/react-native/releases/tag/v0.50.0)
 
 target 'TestApp' do
   # Uncomment the next line if you're using Swift or would like to use dynamic frameworks

--- a/TestApp/ios/BrownfieldPodfileExample
+++ b/TestApp/ios/BrownfieldPodfileExample
@@ -1,0 +1,31 @@
+# Example Podfile for brownfield react native application
+# For more information about using `react-native link` install pods for brownfield application, 
+# please refer to https://github.com/facebook/react-native/commit/74146cb3158273921b768c97f229695e680ea82d
+
+target 'TestApp' do
+  # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
+  # use_frameworks!
+
+  pod 'React', path: '../node_modules/react-native', subspecs: [
+    'Core',
+    'RCTText',
+    'RCTNetwork',
+    'RCTWebSocket',
+    'BatchedBridge',
+    'RCTImage',
+    'DevSupport',
+    'RCTAnimation',
+    'RCTActionSheet',
+    'RCTLinkingIOS',
+  ]
+  pod 'yoga', path: '../node_modules/react-native/ReactCommon/yoga'
+
+  # Add new pods below this line
+
+  pod 'appcenter', path: '../node_modules/appcenter/ios'
+  pod 'appcenter-analytics', path: '../node_modules/appcenter-analytics/ios'
+  pod 'appcenter-crashes', path: '../node_modules/appcenter-crashes/ios'
+  pod 'appcenter-push', path: '../node_modules/appcenter-push/ios'
+
+  platform :ios, '8.0'
+end

--- a/appcenter-analytics/ios/appcenter-analytics.podspec
+++ b/appcenter-analytics/ios/appcenter-analytics.podspec
@@ -1,0 +1,23 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name              = package['name']
+  s.version           = package['version']
+  s.summary           = package['description']
+  s.license           = package['license']
+  s.homepage          = package['homepage']
+  s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/"
+
+  s.author           = { 'Microsoft' => 'appcentersdk@microsoft.com' }
+
+  s.source = { :git => "https://github.com/Microsoft/AppCenter-SDK-React-Native.git" }
+  s.source_files = "appcenter-analytics/ios/AppCenterReactNativeAnalytics/*.{h,m}"
+  s.platform          = :ios, '8.0'
+  s.requires_arc      = true
+
+  s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
+
+  s.dependency 'AppCenterReactNativeShared'
+end

--- a/appcenter-crashes/ios/appcenter-crashes.podspec
+++ b/appcenter-crashes/ios/appcenter-crashes.podspec
@@ -1,0 +1,23 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name              = package['name']
+  s.version           = package['version']
+  s.summary           = package['description']
+  s.license           = package['license']
+  s.homepage          = package['homepage']
+  s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/"
+
+  s.author           = { 'Microsoft' => 'appcentersdk@microsoft.com' }
+
+  s.source = { :git => "https://github.com/Microsoft/AppCenter-SDK-React-Native.git" }
+  s.source_files = "appcenter-crashes/ios/AppCenterReactNativeCrashes/*.{h,m}"
+  s.platform          = :ios, '8.0'
+  s.requires_arc      = true
+
+  s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
+
+  s.dependency 'AppCenterReactNativeShared'
+end

--- a/appcenter-push/ios/appcenter-push.podspec
+++ b/appcenter-push/ios/appcenter-push.podspec
@@ -1,0 +1,23 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name              = package['name']
+  s.version           = package['version']
+  s.summary           = package['description']
+  s.license           = package['license']
+  s.homepage          = package['homepage']
+  s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/"
+
+  s.author           = { 'Microsoft' => 'appcentersdk@microsoft.com' }
+
+  s.source = { :git => "https://github.com/Microsoft/AppCenter-SDK-React-Native.git" }
+  s.source_files = "appcenter-push/ios/AppCenterReactNativePush/*.{h,m}"
+  s.platform          = :ios, '8.0'
+  s.requires_arc      = true
+
+  s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
+
+  s.dependency 'AppCenterReactNativeShared'
+end

--- a/appcenter/ios/appcenter.podspec
+++ b/appcenter/ios/appcenter.podspec
@@ -1,0 +1,23 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name              = package['name']
+  s.version           = package['version']
+  s.summary           = package['description']
+  s.license           = package['license']
+  s.homepage          = package['homepage']
+  s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/"
+
+  s.author           = { 'Microsoft' => 'appcentersdk@microsoft.com' }
+
+  s.source = { :git => "https://github.com/Microsoft/AppCenter-SDK-React-Native.git" }
+  s.source_files = "appcenter/ios/AppCenterReactNative/*.{h,m}"
+  s.platform          = :ios, '8.0'
+  s.requires_arc      = true
+
+  s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
+
+  s.dependency 'AppCenterReactNativeShared'
+end


### PR DESCRIPTION
Starting from [react-native@0.50.0](https://github.com/facebook/react-native/releases/tag/v0.50.0), `react-native link` supports installing from `Podfile` for brownfield react native applications.

> This change will allow to link projects that contains its own .podspec file to CocoaPods-based projects. In case link detect Podfile in iOS directory, it will look for related .podspec file in linked project directory, and add it to Podfile. If Podfile and .podspec files are not present, it will fall back to previous implementation.

Previously it's difficult to install appcenter dependencies from Podfile via `pod install`. Even with `pod install` installed appcenter dependencies, users still need to figure out how to run rnpm postinstall script to configure appcenter-analytics and appcenter-crashes module correctly. With `react-native link` supports `Podfile` out-of-box, it's much easier to use our sdk in brownfield applications.

This should fix #94.