### PR TITLE
Custom text and binary attachments in test apps

### DIFF
--- a/TestApp/AttachmentsProvider.js
+++ b/TestApp/AttachmentsProvider.js
@@ -10,60 +10,60 @@ const DEFAULT_FILENAME = 'binary.txt';
 const DEFAULT_ENCODING = 'utf8';
 
 export default class AttachmentsProvider {
-    static async saveTextAttachment(value) {
-        await AsyncStorage.setItem(TEXT_ATTACHMENT_KEY, value);
-    }
+  static async saveTextAttachment(value) {
+    await AsyncStorage.setItem(TEXT_ATTACHMENT_KEY, value);
+  }
 
-    static async getTextAttachment() {
-        return getItemFromStorage(TEXT_ATTACHMENT_KEY, 'hello');
-    }
+  static async getTextAttachment() {
+    return getItemFromStorage(TEXT_ATTACHMENT_KEY, 'hello');
+  }
 
-    static async saveBinaryAttachment(name, data, type, size) {
-        AsyncStorage.setItem(BINARY_FILENAME_KEY, name);
-        AsyncStorage.setItem(BINARY_FILETYPE_KEY, type);
-        AsyncStorage.setItem(BINARY_FILESIZE_KEY, size);
-        saveFileInDocumentsFolder(DEFAULT_FILENAME, data);
-    }
+  static async saveBinaryAttachment(name, data, type, size) {
+    AsyncStorage.setItem(BINARY_FILENAME_KEY, name);
+    AsyncStorage.setItem(BINARY_FILETYPE_KEY, type);
+    AsyncStorage.setItem(BINARY_FILESIZE_KEY, size);
+    saveFileInDocumentsFolder(DEFAULT_FILENAME, data);
+  }
 
-    static async getBinaryAttachment() {
-        const path = `${RNFS.DocumentDirectoryPath}/${DEFAULT_FILENAME}`;
-        let contents = '';
-        try {
-            contents = await RNFS.readFile(path, DEFAULT_ENCODING);
-        } catch (error) {
-            console.error('Error while reading binary attachment file');
-        }
-        return contents;
+  static async getBinaryAttachment() {
+    const path = `${RNFS.DocumentDirectoryPath}/${DEFAULT_FILENAME}`;
+    let contents = '';
+    try {
+      contents = await RNFS.readFile(path, DEFAULT_ENCODING);
+    } catch (error) {
+      console.error('Error while reading binary attachment file');
     }
+    return contents;
+  }
 
-    static async getBinaryName() {
-        return getItemFromStorage(BINARY_FILENAME_KEY);
-    }
+  static async getBinaryName() {
+    return getItemFromStorage(BINARY_FILENAME_KEY);
+  }
 
-    static async getBinaryType() {
-        return getItemFromStorage(BINARY_FILETYPE_KEY);
-    }
+  static async getBinaryType() {
+    return getItemFromStorage(BINARY_FILETYPE_KEY);
+  }
 
-    static async getBinaryAttachmentInfo() {
-        const fileName = await getItemFromStorage(BINARY_FILENAME_KEY);
-        const fileSize = await getItemFromStorage(BINARY_FILESIZE_KEY);
-        return `${fileName} (${fileSize})`;
-    }
+  static async getBinaryAttachmentInfo() {
+    const fileName = await getItemFromStorage(BINARY_FILENAME_KEY);
+    const fileSize = await getItemFromStorage(BINARY_FILESIZE_KEY);
+    return `${fileName} (${fileSize})`;
+  }
 }
 
 async function getItemFromStorage(key, defaultValue = '') {
-    try {
-        return await AsyncStorage.getItem(key);
-    } catch (error) {
-        console.error(`Error retrieving item with key: ${key}`);
-        console.error(error.message);
-    }
-    return defaultValue;
+  try {
+    return await AsyncStorage.getItem(key);
+  } catch (error) {
+    console.error(`Error retrieving item with key: ${key}`);
+    console.error(error.message);
+  }
+  return defaultValue;
 }
 
 async function saveFileInDocumentsFolder(fileName, data) {
-    const path = `${RNFS.DocumentDirectoryPath}/${fileName}`;
-    RNFS.writeFile(path, data, DEFAULT_ENCODING)
-        .then(() => console.log('Binary attachment saved'))
-        .catch(err => console.error(err.message));
+  const path = `${RNFS.DocumentDirectoryPath}/${fileName}`;
+  RNFS.writeFile(path, data, DEFAULT_ENCODING)
+    .then(() => console.log('Binary attachment saved'))
+    .catch(err => console.error(err.message));
 }

--- a/TestApp/AttachmentsProvider.js
+++ b/TestApp/AttachmentsProvider.js
@@ -1,0 +1,75 @@
+import React, { Component } from 'react';
+import { AsyncStorage} from 'react-native';
+import RNFS from 'react-native-fs';
+
+const TEXT_ATTACHMENT_KEY = 'TEXT_ATTACHMENT_KEY';
+const BINARY_FILENAME_KEY = 'BINARY_FILENAME_KEY';
+const BINARY_FILETYPE_KEY = 'BINARY_FILETYPE_KEY';
+const BINARY_FILESIZE_KEY = 'BINARY_FILESIZE_KEY';
+
+const DEFAULT_FILENAME = 'binary.txt';
+const DEFAULT_ENCODING = 'utf8';
+
+export default class AttachmentsProvider  {
+
+    static async saveTextAttachment(value) {
+        await AsyncStorage.setItem(TEXT_ATTACHMENT_KEY, value);
+    }
+
+    static async getTextAttachment() {
+        return await getItemFromStorage(TEXT_ATTACHMENT_KEY, 'hello');
+    }
+
+    static async saveBinaryAttachment(name, data, type, size) {
+        AsyncStorage.setItem(BINARY_FILENAME_KEY, name);
+        AsyncStorage.setItem(BINARY_FILETYPE_KEY, type);
+        AsyncStorage.setItem(BINARY_FILESIZE_KEY, size);
+        saveFileInDocumentsFolder(DEFAULT_FILENAME, data);
+    }
+
+    static async getBinaryAttachment() {
+        var path = RNFS.DocumentDirectoryPath + '/' + DEFAULT_FILENAME;
+        var contents = '';
+        try {
+            contents = await RNFS.readFile(path, DEFAULT_ENCODING)
+        } catch (error) {
+            console.log('Error while reading binary attachment file');
+        }
+        return contents;
+    }
+
+    static async getBinaryName() {
+        return await getItemFromStorage(BINARY_FILENAME_KEY);
+    }
+
+    static async getBinaryType() {
+        return await getItemFromStorage(BINARY_FILETYPE_KEY);
+    }
+
+    static async getBinaryAttachmentInfo() {
+        let fileName = await getItemFromStorage(BINARY_FILENAME_KEY);
+        let fileSize = await getItemFromStorage(BINARY_FILESIZE_KEY);
+        return fileName + ' (' + fileSize + ')';
+    }
+}
+
+async function getItemFromStorage(key, defaultValue = '') {
+    try {
+        return await AsyncStorage.getItem(key);
+    } catch (error) {
+        console.log('Error retrieving item with key: ' + key);
+        console.log(error.message);
+    }
+    return defaultValue;
+}
+
+async function saveFileInDocumentsFolder(fileName, data) {
+    var path = RNFS.DocumentDirectoryPath + '/' + fileName;
+    RNFS.writeFile(path, data, DEFAULT_ENCODING)
+        .then((success) => {
+            console.log('Binary attachment saved');
+        })
+        .catch((err) => {
+            console.log(err.message);
+        });
+}

--- a/TestApp/AttachmentsProvider.js
+++ b/TestApp/AttachmentsProvider.js
@@ -1,5 +1,4 @@
-import React, { Component } from 'react';
-import { AsyncStorage} from 'react-native';
+import { AsyncStorage } from 'react-native';
 import RNFS from 'react-native-fs';
 
 const TEXT_ATTACHMENT_KEY = 'TEXT_ATTACHMENT_KEY';
@@ -10,14 +9,13 @@ const BINARY_FILESIZE_KEY = 'BINARY_FILESIZE_KEY';
 const DEFAULT_FILENAME = 'binary.txt';
 const DEFAULT_ENCODING = 'utf8';
 
-export default class AttachmentsProvider  {
-
+export default class AttachmentsProvider {
     static async saveTextAttachment(value) {
         await AsyncStorage.setItem(TEXT_ATTACHMENT_KEY, value);
     }
 
     static async getTextAttachment() {
-        return await getItemFromStorage(TEXT_ATTACHMENT_KEY, 'hello');
+        return getItemFromStorage(TEXT_ATTACHMENT_KEY, 'hello');
     }
 
     static async saveBinaryAttachment(name, data, type, size) {
@@ -28,28 +26,28 @@ export default class AttachmentsProvider  {
     }
 
     static async getBinaryAttachment() {
-        var path = RNFS.DocumentDirectoryPath + '/' + DEFAULT_FILENAME;
-        var contents = '';
+        const path = `${RNFS.DocumentDirectoryPath}/${DEFAULT_FILENAME}`;
+        let contents = '';
         try {
-            contents = await RNFS.readFile(path, DEFAULT_ENCODING)
+            contents = await RNFS.readFile(path, DEFAULT_ENCODING);
         } catch (error) {
-            console.log('Error while reading binary attachment file');
+            console.error('Error while reading binary attachment file');
         }
         return contents;
     }
 
     static async getBinaryName() {
-        return await getItemFromStorage(BINARY_FILENAME_KEY);
+        return getItemFromStorage(BINARY_FILENAME_KEY);
     }
 
     static async getBinaryType() {
-        return await getItemFromStorage(BINARY_FILETYPE_KEY);
+        return getItemFromStorage(BINARY_FILETYPE_KEY);
     }
 
     static async getBinaryAttachmentInfo() {
-        let fileName = await getItemFromStorage(BINARY_FILENAME_KEY);
-        let fileSize = await getItemFromStorage(BINARY_FILESIZE_KEY);
-        return fileName + ' (' + fileSize + ')';
+        const fileName = await getItemFromStorage(BINARY_FILENAME_KEY);
+        const fileSize = await getItemFromStorage(BINARY_FILESIZE_KEY);
+        return `${fileName} (${fileSize})`;
     }
 }
 
@@ -57,19 +55,15 @@ async function getItemFromStorage(key, defaultValue = '') {
     try {
         return await AsyncStorage.getItem(key);
     } catch (error) {
-        console.log('Error retrieving item with key: ' + key);
-        console.log(error.message);
+        console.error(`Error retrieving item with key: ${key}`);
+        console.error(error.message);
     }
     return defaultValue;
 }
 
 async function saveFileInDocumentsFolder(fileName, data) {
-    var path = RNFS.DocumentDirectoryPath + '/' + fileName;
+    const path = `${RNFS.DocumentDirectoryPath}/${fileName}`;
     RNFS.writeFile(path, data, DEFAULT_ENCODING)
-        .then((success) => {
-            console.log('Binary attachment saved');
-        })
-        .catch((err) => {
-            console.log(err.message);
-        });
+        .then(() => console.log('Binary attachment saved'))
+        .catch(err => console.error(err.message));
 }

--- a/TestApp/CrashesScreen.js
+++ b/TestApp/CrashesScreen.js
@@ -28,9 +28,8 @@ export default class CrashesScreen extends Component {
     this.state = {
       crashesEnabled: false,
       lastSessionStatus: '',
-      sendStatus: '',
-      textAttachment:'',
-      binaryAttachment:''
+      textAttachment: '',
+      binaryAttachment: ''
     };
     this.toggleEnabled = this.toggleEnabled.bind(this);
     this.jsCrash = this.jsCrash.bind(this);
@@ -57,11 +56,11 @@ export default class CrashesScreen extends Component {
       component.setState({ lastSessionStatus: status });
     }
 
-     const textAttachment = await AttachmentsProvider.getTextAttachment();
-     component.setState({textAttachment: textAttachment});
+     const textAttachmentValue = await AttachmentsProvider.getTextAttachment();
+     component.setState({ textAttachment: textAttachmentValue });
 
-     const binaryAttachment = await AttachmentsProvider.getBinaryAttachmentInfo();
-     component.setState({binaryAttachment: binaryAttachment});
+     const binaryAttachmentValue = await AttachmentsProvider.getBinaryAttachmentInfo();
+     component.setState({ binaryAttachment: binaryAttachmentValue });
   }
 
   async toggleEnabled() {
@@ -105,16 +104,16 @@ export default class CrashesScreen extends Component {
               Crash native code
             </Text>
           </TouchableOpacity>
-          <TouchableOpacity onPress={() => {this.dialogComponent.show()}}>
-          <Text style={styles.button}>
-              Set text attachmet
-          </Text>
+          <TouchableOpacity onPress={() => { this.dialogComponent.show(); }}>
+            <Text style={styles.button}>
+              Set text error attachment
+            </Text>
           </TouchableOpacity>
           <Text style={SharedStyles.enabledText}>{'Current value:'}{this.state.textAttachment}</Text>
           <TouchableOpacity onPress={this.showFilePicker}>
-          <Text style={styles.button}>
-              Set file attachmet
-          </Text>
+            <Text style={styles.button}>
+              Select image as binary error attachment
+            </Text>
           </TouchableOpacity>
           <Text style={SharedStyles.enabledText}>{'Current value:'}{this.state.binaryAttachment}</Text>
           <Text style={styles.lastSessionHeader}>Last session:</Text>
@@ -128,50 +127,54 @@ export default class CrashesScreen extends Component {
   }
 
   getTextAttachmentDialog() {
-    return(                
-      <DialogComponent 
+    return (
+      <DialogComponent
         ref={(dialogComponent) => { this.dialogComponent = dialogComponent; }}
-        width={0.9}>
+        width={0.9}
+      >
         <View>
-            <TextInput
-            style={{height: 40, borderColor: 'gray', borderWidth: 1, margin: 8}}
-            onChangeText = {(text) => this.setState({ textAttachment: text })}/>
-            <View style={{flex: 1, flexDirection: 'row', justifyContent: 'space-between',}}>
+          <TextInput
+            style={{
+               height: 40, borderColor: 'gray', borderWidth: 1, margin: 8
+              }}
+            onChangeText={text => this.setState({ textAttachment: text })}
+          />
+          <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'space-between' }}>
             <TouchableOpacity
-                style={{height:50}}
-                onPress={() => {
+              style={{ height: 50 }}
+              onPress={() => {
                     AttachmentsProvider.saveTextAttachment(this.state.textAttachment);
                     this.dialogComponent.dismiss();
-                }}>
-                <Text style={styles.button}>
+              }}
+            >
+              <Text style={styles.button}>
                 Save
-                </Text>
+              </Text>
             </TouchableOpacity>
             <TouchableOpacity
-                style={{height:50}}
-                onPress={() => {this.dialogComponent.dismiss()}}>
-                <Text style={styles.button}>
+              style={{ height: 50 }}
+              onPress={() => { this.dialogComponent.dismiss(); }}
+            >
+              <Text style={styles.button}>
                 Cancel
-                </Text>
+              </Text>
             </TouchableOpacity>
-            </View>
+          </View>
         </View>
       </DialogComponent>
     );
   }
 
   showFilePicker() {
-    ImagePicker.showImagePicker(null, async (response) => {    
+    ImagePicker.showImagePicker(null, async (response) => {
       if (response.didCancel) {
         console.log('User cancelled image picker');
-      }
-      else if (response.error) {
+      } else if (response.error) {
         console.log('ImagePicker Error: ', response.error);
-      }
-      else {
+      } else {
         AttachmentsProvider.saveBinaryAttachment(getFileName(response), response.data, getFileType(response), getFileSize(response));
-        let binaryAttachment = await AttachmentsProvider.getBinaryAttachmentInfo()
-        this.setState({ binaryAttachment: binaryAttachment });
+        const binaryAttachmentValue = await AttachmentsProvider.getBinaryAttachmentInfo();
+        this.setState({ binaryAttachment: binaryAttachmentValue });
       }
     });
 
@@ -184,10 +187,10 @@ export default class CrashesScreen extends Component {
     }
 
     function getFileSize(response) {
-      var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-      if (response.fileSize == 0) return '0 Byte';
-      var i = parseInt(Math.floor(Math.log(response.fileSize) / Math.log(1024)));
-      return Math.round(response.fileSize / Math.pow(1024, i), 2) + ' ' + sizes[i];
+      const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+      if (response.fileSize === 0) return '0 Byte';
+      const i = parseInt(Math.floor(Math.log(response.fileSize) / Math.log(1024)));
+      return `${Math.round(response.fileSize / (1024 ** i), 2)} ${sizes[i]}`;
     }
   }
 }

--- a/TestApp/CrashesScreen.js
+++ b/TestApp/CrashesScreen.js
@@ -128,20 +128,12 @@ export default class CrashesScreen extends Component {
 
   getTextAttachmentDialog() {
     return (
-      <DialogComponent
-        ref={(dialogComponent) => { this.dialogComponent = dialogComponent; }}
-        width={0.9}
-      >
+      <DialogComponent ref={(dialogComponent) => { this.dialogComponent = dialogComponent; }} width={0.9}>
         <View>
-          <TextInput
-            style={{
-               height: 40, borderColor: 'gray', borderWidth: 1, margin: 8
-              }}
-            onChangeText={text => this.setState({ textAttachment: text })}
-          />
-          <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'space-between' }}>
+          <TextInput style={SharedStyles.dialogInput} onChangeText={text => this.setState({ textAttachment: text })} />
+          <View style={SharedStyles.dialogButtonContainer}>
             <TouchableOpacity
-              style={{ height: 50 }}
+              style={SharedStyles.dialogButton}
               onPress={() => {
                     AttachmentsProvider.saveTextAttachment(this.state.textAttachment);
                     this.dialogComponent.dismiss();
@@ -151,10 +143,7 @@ export default class CrashesScreen extends Component {
                 Save
               </Text>
             </TouchableOpacity>
-            <TouchableOpacity
-              style={{ height: 50 }}
-              onPress={() => { this.dialogComponent.dismiss(); }}
-            >
+            <TouchableOpacity style={SharedStyles.dialogButton} onPress={() => { this.dialogComponent.dismiss(); }}>
               <Text style={styles.button}>
                 Cancel
               </Text>
@@ -179,11 +168,11 @@ export default class CrashesScreen extends Component {
     });
 
     function getFileName(response) {
-      return response.fileName != null ? response.fileName : 'binary.jpeg';
+      return response.fileName !== null ? response.fileName : 'binary.jpeg';
     }
 
     function getFileType(response) {
-      return response.type != null ? response.type : 'image/jpeg';
+      return response.type !== null ? response.type : 'image/jpeg';
     }
 
     function getFileSize(response) {

--- a/TestApp/CrashesScreen.js
+++ b/TestApp/CrashesScreen.js
@@ -187,10 +187,18 @@ export default class CrashesScreen extends Component {
     }
 
     function getFileSize(response) {
-      const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-      if (response.fileSize === 0) return '0 Byte';
-      const i = parseInt(Math.floor(Math.log(response.fileSize) / Math.log(1024)));
-      return `${Math.round(response.fileSize / (1024 ** i), 2)} ${sizes[i]}`;
+      const thresh = 1024;
+      const units = ['KiB', 'MiB', 'GiB'];
+      let fileSize = response.fileSize;
+      if (Math.abs(fileSize) < thresh) {
+          return `${fileSize} B`;
+      }
+      let u = -1;
+      do {
+        fileSize /= thresh;
+          ++u;
+      } while (Math.abs(fileSize) >= thresh && u < units.length - 1);
+      return `${fileSize.toFixed(1)} ${units[u]}`;
     }
   }
 }

--- a/TestApp/CrashesScreen.js
+++ b/TestApp/CrashesScreen.js
@@ -196,7 +196,7 @@ export default class CrashesScreen extends Component {
       let u = -1;
       do {
         fileSize /= thresh;
-          ++u;
+        ++u;
       } while (Math.abs(fileSize) >= thresh && u < units.length - 1);
       return `${fileSize.toFixed(1)} ${units[u]}`;
     }

--- a/TestApp/MainScreen.js
+++ b/TestApp/MainScreen.js
@@ -42,8 +42,7 @@ export default class MainScreen extends Component {
 
 Push.setListener({
   onPushNotificationReceived(pushNotification) {
-    let message = pushNotification.message;
-    let title = pushNotification.title;
+    let [message, title] = pushNotification;
 
     if (message === null || message === undefined) {
       // Android messages received in the background don't include a message. On Android, that fact can be used to
@@ -97,16 +96,16 @@ Crashes.setListener({
 
   getErrorAttachments(report) {
     console.log(`Get error attachments for report with id: ${report.id}'`);
-    return new Promise(async (resolve, reject) => {
-      let textAttachment = await AttachmentsProvider.getTextAttachment();
-      let binaryAttachment = await AttachmentsProvider.getBinaryAttachment();
-      let binaryName = await AttachmentsProvider.getBinaryName(); 
-      let binaryType = await AttachmentsProvider.getBinaryType(); 
-      resolve([
-        ErrorAttachmentLog.attachmentWithText(textAttachment, 'hello.txt'),
-        ErrorAttachmentLog.attachmentWithBinary(binaryAttachment, binaryName, binaryType)
+    return (async () => {
+      const [textAttachment, binaryAttachment, binaryName, binaryType] = await Promise.all([
+        AttachmentsProvider.getTextAttachment(),
+        AttachmentsProvider.getBinaryAttachment(),
+        AttachmentsProvider.getBinaryName(),
+        AttachmentsProvider.getBinaryType(),
       ]);
-    });
+      return [ErrorAttachmentLog.attachmentWithText(textAttachment, 'hello.txt'),
+        ErrorAttachmentLog.attachmentWithBinary(binaryAttachment, binaryName, binaryType)];
+    })();
   },
 
   onBeforeSending() {

--- a/TestApp/MainScreen.js
+++ b/TestApp/MainScreen.js
@@ -95,16 +95,18 @@ Crashes.setListener({
     return true;
   },
 
-  async getErrorAttachments(report) {
+  getErrorAttachments(report) {
     console.log(`Get error attachments for report with id: ${report.id}'`);
-    let textAttachment = await AttachmentsProvider.getTextAttachment();
-    let binaryAttachment = await AttachmentsProvider.getBinaryAttachment();
-    let binaryName = await AttachmentsProvider.getBinaryName(); 
-    let binaryType = await AttachmentsProvider.getBinaryType(); 
-    return [
-      ErrorAttachmentLog.attachmentWithText(textAttachment, 'hello.txt'),
-      ErrorAttachmentLog.attachmentWithBinary(binaryAttachment, binaryName, binaryType)
-    ];
+    return new Promise(async (resolve, reject) => {
+      let textAttachment = await AttachmentsProvider.getTextAttachment();
+      let binaryAttachment = await AttachmentsProvider.getBinaryAttachment();
+      let binaryName = await AttachmentsProvider.getBinaryName(); 
+      let binaryType = await AttachmentsProvider.getBinaryType(); 
+      resolve([
+        ErrorAttachmentLog.attachmentWithText(textAttachment, 'hello.txt'),
+        ErrorAttachmentLog.attachmentWithBinary(binaryAttachment, binaryName, binaryType)
+      ]);
+    });
   },
 
   onBeforeSending() {

--- a/TestApp/MainScreen.js
+++ b/TestApp/MainScreen.js
@@ -5,11 +5,14 @@
  */
 
 import React, { Component } from 'react';
-import { AppState, Alert, Button, View, Platform, ToastAndroid, Text } from 'react-native';
+import { AppState, Alert, Button, View, Platform, ToastAndroid, Text, AsyncStorage } from 'react-native';
 import AppCenter from 'appcenter';
 import Crashes, { UserConfirmation, ErrorAttachmentLog } from 'appcenter-crashes';
 import Push from 'appcenter-push';
 import SharedStyles from './SharedStyles';
+
+const TEXT_ATTACHMENT_KEY = 'TEXT_ATTACHMENT_KEY';
+const BINARY_ATTACHMENT_KEY = 'BINARY_ATTACHMENT_KEY';
 
 export default class MainScreen extends Component {
   constructor() {
@@ -95,10 +98,16 @@ Crashes.setListener({
     return true;
   },
 
-  getErrorAttachments(report) {
+  async getErrorAttachments(report) {
     console.log(`Get error attachments for report with id: ${report.id}'`);
+    let textAttachment = "hello";
+    try {
+      textAttachment = await AsyncStorage.getItem(TEXT_ATTACHMENT_KEY);
+    } catch (error) {
+      console.log("Error retrieving text attachment: " + error.message);
+    }
     return [
-      ErrorAttachmentLog.attachmentWithText('hello', 'hello.txt'),
+      ErrorAttachmentLog.attachmentWithText(textAttachment, 'hello.txt'),
       ErrorAttachmentLog.attachmentWithBinary(testIcon, 'icon.png', 'image/png')
     ];
   },

--- a/TestApp/MainScreen.js
+++ b/TestApp/MainScreen.js
@@ -5,14 +5,12 @@
  */
 
 import React, { Component } from 'react';
-import { AppState, Alert, Button, View, Platform, ToastAndroid, Text, AsyncStorage } from 'react-native';
+import { AppState, Alert, Button, View, Platform, ToastAndroid, Text } from 'react-native';
 import AppCenter from 'appcenter';
 import Crashes, { UserConfirmation, ErrorAttachmentLog } from 'appcenter-crashes';
 import Push from 'appcenter-push';
 import SharedStyles from './SharedStyles';
-
-const TEXT_ATTACHMENT_KEY = 'TEXT_ATTACHMENT_KEY';
-const BINARY_ATTACHMENT_KEY = 'BINARY_ATTACHMENT_KEY';
+import AttachmentsProvider from './AttachmentsProvider';
 
 export default class MainScreen extends Component {
   constructor() {
@@ -28,7 +26,6 @@ export default class MainScreen extends Component {
 
   render() {
     const { navigate } = this.props.navigation;
-
     return (
       <View style={SharedStyles.container}>
         <Text style={SharedStyles.heading}>
@@ -100,15 +97,13 @@ Crashes.setListener({
 
   async getErrorAttachments(report) {
     console.log(`Get error attachments for report with id: ${report.id}'`);
-    let textAttachment = "hello";
-    try {
-      textAttachment = await AsyncStorage.getItem(TEXT_ATTACHMENT_KEY);
-    } catch (error) {
-      console.log("Error retrieving text attachment: " + error.message);
-    }
+    let textAttachment = await AttachmentsProvider.getTextAttachment();
+    let binaryAttachment = await AttachmentsProvider.getBinaryAttachment();
+    let binaryName = await AttachmentsProvider.getBinaryName(); 
+    let binaryType = await AttachmentsProvider.getBinaryType(); 
     return [
       ErrorAttachmentLog.attachmentWithText(textAttachment, 'hello.txt'),
-      ErrorAttachmentLog.attachmentWithBinary(testIcon, 'icon.png', 'image/png')
+      ErrorAttachmentLog.attachmentWithBinary(binaryAttachment, binaryName, binaryType)
     ];
   },
 
@@ -124,18 +119,3 @@ Crashes.setListener({
     console.log('Failed sending crash. onSendingFailed is invoked.');
   }
 });
-
-const testIcon = `iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGP
-C/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3Cc
-ulE8AAAA1VBMVEXLLmPLLWPLLWLMMWXLLGLMMmbcdJftt8nYY4vKLGHSSXfp
-qL799fj////oobnVVYDUUX3LL2TccpX12OL88fXrsMT56O7NNWjhhaT56O3S
-SHfTT3z56e777vPcc5bQQXH22+Tuvc7sssX++vv66/DuvM3sssbYZIv22uT7
-7vLvvs79+PrUUH3OOmzjjqr66u/99vj23OXZZo3YYIn89Pf++fv22uPYYorX
-YIjZaI767PHuusz99/nbb5TPQHDqqsD55+3ggqL55ez11+HRSHfUUn7TT3vg
-lpRpAAAAAWJLR0QN9rRh9QAAAJpJREFUGNNjYMAKGJmYmZD5LKxs7BxMDJws
-UD4nFzcPLx8LA7+AIJjPKiQsIirGJy4hKSwFUsMpLSMrJ6+gqKTMqyLACRRg
-klflUVPX4NXU0lbRAQkwMOnqiegbGBoZmyAJaJqamVtABYBaDNgtDXmtrG0g
-AkBDNW3tFFRFTaGGgqyVtXfgE3d0cnZhQXYYk6ubIA6nY3oOGQAAubQPeKPu
-sH8AAAAldEVYdGRhdGU6Y3JlYXRlADIwMTctMDctMjhUMDM6NDE6MTUrMDI6
-MDAk+3aMAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE3LTA3LTI4VDAzOjQxOjE1
-KzAyOjAwVabOMAAAAABJRU5ErkJggg==`;

--- a/TestApp/SharedStyles.js
+++ b/TestApp/SharedStyles.js
@@ -34,6 +34,20 @@ const SharedStyles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 10,
   },
+  dialogInput: {
+    height: 40,
+    borderColor: 'gray',
+    borderWidth: 1,
+    margin: 8
+  },
+  dialogButton: {
+    height: 50
+  },
+  dialogButtonContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
 });
 
 export default SharedStyles;

--- a/TestApp/android/app/build.gradle
+++ b/TestApp/android/app/build.gradle
@@ -127,6 +127,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-fs')
     compile project(':react-native-image-picker')
     compile project(':appcenter-push')
     compile project(':appcenter-crashes')

--- a/TestApp/android/app/build.gradle
+++ b/TestApp/android/app/build.gradle
@@ -127,6 +127,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-image-picker')
     compile project(':appcenter-push')
     compile project(':appcenter-crashes')
     compile project(':appcenter-analytics')

--- a/TestApp/android/app/src/main/AndroidManifest.xml
+++ b/TestApp/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-sdk
         android:minSdkVersion="16"
         android:targetSdkVersion="22" />

--- a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+++ b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
+import com.imagepicker.ImagePickerPackage;
 import com.microsoft.appcenter.reactnative.push.AppCenterReactNativePushPackage;
 import com.microsoft.appcenter.reactnative.crashes.AppCenterReactNativeCrashesPackage;
 import com.microsoft.appcenter.reactnative.analytics.AppCenterReactNativeAnalyticsPackage;
@@ -30,6 +31,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new ImagePickerPackage(),
             new AppCenterReactNativePushPackage(MainApplication.this),
             new AppCenterReactNativePackage(MainApplication.this),
             new AppCenterReactNativeCrashesPackage(MainApplication.this, getResources().getString(R.string.appCenterCrashes_whenToSendCrashes)),

--- a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+++ b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
+import com.rnfs.RNFSPackage;
 import com.imagepicker.ImagePickerPackage;
 import com.microsoft.appcenter.reactnative.push.AppCenterReactNativePushPackage;
 import com.microsoft.appcenter.reactnative.crashes.AppCenterReactNativeCrashesPackage;
@@ -31,6 +32,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new RNFSPackage(),
             new ImagePickerPackage(),
             new AppCenterReactNativePushPackage(MainApplication.this),
             new AppCenterReactNativePackage(MainApplication.this),

--- a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+++ b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
@@ -4,18 +4,18 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
-import com.rnfs.RNFSPackage;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.shell.MainReactPackage;
+import com.facebook.soloader.SoLoader;
 import com.imagepicker.ImagePickerPackage;
 import com.microsoft.appcenter.reactnative.push.AppCenterReactNativePushPackage;
 import com.microsoft.appcenter.reactnative.crashes.AppCenterReactNativeCrashesPackage;
 import com.microsoft.appcenter.reactnative.analytics.AppCenterReactNativeAnalyticsPackage;
 import com.microsoft.appcenter.reactnative.appcenter.AppCenterReactNativePackage;
 import com.microsoft.appcenter.AppCenter;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactPackage;
-import com.facebook.react.shell.MainReactPackage;
-import com.facebook.soloader.SoLoader;
+import com.rnfs.RNFSPackage;
 
 import java.util.Arrays;
 import java.util.List;

--- a/TestApp/android/settings.gradle
+++ b/TestApp/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'TestApp'
+include ':react-native-fs'
+project(':react-native-fs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fs/android')
 include ':react-native-image-picker'
 project(':react-native-image-picker').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-image-picker/android')
 include ':appcenter-push'

--- a/TestApp/android/settings.gradle
+++ b/TestApp/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'TestApp'
+include ':react-native-image-picker'
+project(':react-native-image-picker').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-image-picker/android')
 include ':appcenter-push'
 project(':appcenter-push').projectDir = new File(rootProject.projectDir, '../node_modules/appcenter-push/android')
 include ':appcenter-crashes'

--- a/TestApp/ios/Podfile
+++ b/TestApp/ios/Podfile
@@ -14,8 +14,4 @@ target 'TestApp' do
   pod 'AppCenterReactNativeShared', :path => '../../AppCenterReactNativeShared/Products/'
 
   platform :ios, '8.0'
-  pod 'react-native-image-picker', :path => '../node_modules/react-native-image-picker'
-
-  pod 'RNFS', :path => '../node_modules/react-native-fs'
-
 end

--- a/TestApp/ios/Podfile
+++ b/TestApp/ios/Podfile
@@ -16,4 +16,6 @@ target 'TestApp' do
   platform :ios, '8.0'
   pod 'react-native-image-picker', :path => '../node_modules/react-native-image-picker'
 
+  pod 'RNFS', :path => '../node_modules/react-native-fs'
+
 end

--- a/TestApp/ios/Podfile
+++ b/TestApp/ios/Podfile
@@ -14,4 +14,6 @@ target 'TestApp' do
   pod 'AppCenterReactNativeShared', :path => '../../AppCenterReactNativeShared/Products/'
 
   platform :ios, '8.0'
+  pod 'react-native-image-picker', :path => '../node_modules/react-native-image-picker'
+
 end

--- a/TestApp/ios/Pods/Local Podspecs/AppCenterReactNativeShared.podspec.json
+++ b/TestApp/ios/Pods/Local Podspecs/AppCenterReactNativeShared.podspec.json
@@ -4,7 +4,7 @@
   "summary": "React Native plugin for Visual Studio App Center",
   "license": {
     "type": "MIT",
-    "file": "AppCenterReactNativeShared/LICENSE"
+    "file": "AppCenterReactNativeShared/LICENSE.md"
   },
   "homepage": "https://github.com/Microsoft/AppCenter-SDK-React-Native",
   "documentation_url": "https://docs.microsoft.com/en-us/appcenter/",

--- a/TestApp/ios/Pods/Local Podspecs/react-native-image-picker.podspec.json
+++ b/TestApp/ios/Pods/Local Podspecs/react-native-image-picker.podspec.json
@@ -1,0 +1,22 @@
+{
+  "name": "react-native-image-picker",
+  "version": "0.14.3",
+  "license": "MIT",
+  "homepage": "https://github.com/marcshilling/react-native-image-picker",
+  "authors": {
+    "Marc Shilling": "marcshilling@gmail.com"
+  },
+  "summary": "A React Native module that allows you to use the native UIImagePickerController UI to select a photo from the device library or directly from the camera",
+  "source": {
+    "git": "https://github.com/marcshilling/react-native-image-picker"
+  },
+  "source_files": "ios/*.{h,m}",
+  "platforms": {
+    "ios": "7.0"
+  },
+  "dependencies": {
+    "React": [
+
+    ]
+  }
+}

--- a/TestApp/ios/TestApp.xcodeproj/project.pbxproj
+++ b/TestApp/ios/TestApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		5936F98EFBAE465B86B954DB /* libAppCenterReactNativeAnalytics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B57132DB6D74E7B8C6BB11C /* libAppCenterReactNativeAnalytics.a */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		707E4C39CE375B5D347695E4 /* libPods-TestApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BC4D14FCB559ED95B3FFE86F /* libPods-TestApp.a */; };
+		809558431FD5A9A500AB89D7 /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 809558421FD5A98700AB89D7 /* libRNImagePicker.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		86EEAFBD68F743A9ADA002CA /* libAppCenterReactNativePush.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE2CB09C83A4B8798F05E84 /* libAppCenterReactNativePush.a */; };
 		99EBD9770CA344B3A559BFC4 /* AppCenter-Config.plist in Resources */ = {isa = PBXBuildFile; fileRef = 89F88C6A029642FBBE798101 /* AppCenter-Config.plist */; };
@@ -208,6 +209,13 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTLinking;
 		};
+		809558411FD5A98700AB89D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 014A3B5C1C6CF33500B6D375;
+			remoteInfo = RNImagePicker;
+		};
 		832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
@@ -329,6 +337,7 @@
 		4D3B57CBD7BD4293BADDE70A /* libAppCenterReactNativeCrashes.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libAppCenterReactNativeCrashes.a; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
+		809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNImagePicker.xcodeproj; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		89F88C6A029642FBBE798101 /* AppCenter-Config.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = "AppCenter-Config.plist"; path = "TestApp/AppCenter-Config.plist"; sourceTree = "<group>"; };
 		A9CC759A1BFA835A640B2A15 /* Pods-TestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestApp/Pods-TestApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -352,6 +361,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				809558431FD5A9A500AB89D7 /* libRNImagePicker.a in Frameworks */,
 				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
@@ -524,9 +534,18 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		809558191FD5A98700AB89D7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				809558421FD5A98700AB89D7 /* libRNImagePicker.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */,
 				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
@@ -761,6 +780,10 @@
 					ProductGroup = 146834001AC3E56700842450 /* Products */;
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
 				},
+				{
+					ProductGroup = 809558191FD5A98700AB89D7 /* Products */;
+					ProjectRef = 809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */;
+				},
 			);
 			projectRoot = "";
 			targets = (
@@ -937,6 +960,13 @@
 			fileType = archive.ar;
 			path = libRCTLinking.a;
 			remoteRef = 78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		809558421FD5A98700AB89D7 /* libRNImagePicker.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNImagePicker.a;
+			remoteRef = 809558411FD5A98700AB89D7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		832341B51AAA6A8300B99B32 /* libRCTText.a */ = {

--- a/TestApp/ios/TestApp.xcodeproj/project.pbxproj
+++ b/TestApp/ios/TestApp.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		5936F98EFBAE465B86B954DB /* libAppCenterReactNativeAnalytics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B57132DB6D74E7B8C6BB11C /* libAppCenterReactNativeAnalytics.a */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		707E4C39CE375B5D347695E4 /* libPods-TestApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BC4D14FCB559ED95B3FFE86F /* libPods-TestApp.a */; };
-		8037A3CB1FD68F660006BF65 /* libRNFS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8037A3C71FD68F570006BF65 /* libRNFS.a */; };
+		804A72E81FDE7ADA00A12640 /* libRNFS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 804A72E71FDE791400A12640 /* libRNFS.a */; };
 		809558431FD5A9A500AB89D7 /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 809558421FD5A98700AB89D7 /* libRNImagePicker.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		86EEAFBD68F743A9ADA002CA /* libAppCenterReactNativePush.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE2CB09C83A4B8798F05E84 /* libAppCenterReactNativePush.a */; };
@@ -210,19 +210,12 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTLinking;
 		};
-		8037A3C61FD68F570006BF65 /* PBXContainerItemProxy */ = {
+		804A72E61FDE791400A12640 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */;
+			containerPortal = 804A72E21FDE791400A12640 /* RNFS.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F12AFB9B1ADAF8F800E0535D;
 			remoteInfo = RNFS;
-		};
-		8037A3C81FD68F570006BF65 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6456441F1EB8DA9100672408;
-			remoteInfo = "RNFS-tvOS";
 		};
 		809558411FD5A98700AB89D7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -352,7 +345,7 @@
 		4D3B57CBD7BD4293BADDE70A /* libAppCenterReactNativeCrashes.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libAppCenterReactNativeCrashes.a; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
-		8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNFS.xcodeproj; path = "../node_modules/react-native-fs/RNFS.xcodeproj"; sourceTree = "<group>"; };
+		804A72E21FDE791400A12640 /* RNFS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNFS.xcodeproj; path = "../node_modules/react-native-fs/RNFS.xcodeproj"; sourceTree = "<group>"; };
 		809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNImagePicker.xcodeproj; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		89F88C6A029642FBBE798101 /* AppCenter-Config.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = "AppCenter-Config.plist"; path = "TestApp/AppCenter-Config.plist"; sourceTree = "<group>"; };
@@ -377,7 +370,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8037A3CB1FD68F660006BF65 /* libRNFS.a in Frameworks */,
+				804A72E81FDE7ADA00A12640 /* libRNFS.a in Frameworks */,
 				809558431FD5A9A500AB89D7 /* libRNImagePicker.a in Frameworks */,
 				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
@@ -551,11 +544,10 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		8037A39D1FD68F560006BF65 /* Products */ = {
+		804A72E31FDE791400A12640 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				8037A3C71FD68F570006BF65 /* libRNFS.a */,
-				8037A3C91FD68F570006BF65 /* libRNFS.a */,
+				804A72E71FDE791400A12640 /* libRNFS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -571,7 +563,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */,
+				804A72E21FDE791400A12640 /* RNFS.xcodeproj */,
 				809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */,
 				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
@@ -808,8 +800,8 @@
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
 				},
 				{
-					ProductGroup = 8037A39D1FD68F560006BF65 /* Products */;
-					ProjectRef = 8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */;
+					ProductGroup = 804A72E31FDE791400A12640 /* Products */;
+					ProjectRef = 804A72E21FDE791400A12640 /* RNFS.xcodeproj */;
 				},
 				{
 					ProductGroup = 809558191FD5A98700AB89D7 /* Products */;
@@ -993,18 +985,11 @@
 			remoteRef = 78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		8037A3C71FD68F570006BF65 /* libRNFS.a */ = {
+		804A72E71FDE791400A12640 /* libRNFS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRNFS.a;
-			remoteRef = 8037A3C61FD68F570006BF65 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		8037A3C91FD68F570006BF65 /* libRNFS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNFS.a;
-			remoteRef = 8037A3C81FD68F570006BF65 /* PBXContainerItemProxy */;
+			remoteRef = 804A72E61FDE791400A12640 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		809558421FD5A98700AB89D7 /* libRNImagePicker.a */ = {

--- a/TestApp/ios/TestApp.xcodeproj/project.pbxproj
+++ b/TestApp/ios/TestApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		5936F98EFBAE465B86B954DB /* libAppCenterReactNativeAnalytics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B57132DB6D74E7B8C6BB11C /* libAppCenterReactNativeAnalytics.a */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		707E4C39CE375B5D347695E4 /* libPods-TestApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BC4D14FCB559ED95B3FFE86F /* libPods-TestApp.a */; };
+		8037A3CB1FD68F660006BF65 /* libRNFS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8037A3C71FD68F570006BF65 /* libRNFS.a */; };
 		809558431FD5A9A500AB89D7 /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 809558421FD5A98700AB89D7 /* libRNImagePicker.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		86EEAFBD68F743A9ADA002CA /* libAppCenterReactNativePush.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE2CB09C83A4B8798F05E84 /* libAppCenterReactNativePush.a */; };
@@ -209,6 +210,20 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTLinking;
 		};
+		8037A3C61FD68F570006BF65 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F12AFB9B1ADAF8F800E0535D;
+			remoteInfo = RNFS;
+		};
+		8037A3C81FD68F570006BF65 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 6456441F1EB8DA9100672408;
+			remoteInfo = "RNFS-tvOS";
+		};
 		809558411FD5A98700AB89D7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */;
@@ -337,6 +352,7 @@
 		4D3B57CBD7BD4293BADDE70A /* libAppCenterReactNativeCrashes.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libAppCenterReactNativeCrashes.a; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
+		8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNFS.xcodeproj; path = "../node_modules/react-native-fs/RNFS.xcodeproj"; sourceTree = "<group>"; };
 		809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNImagePicker.xcodeproj; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		89F88C6A029642FBBE798101 /* AppCenter-Config.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = "AppCenter-Config.plist"; path = "TestApp/AppCenter-Config.plist"; sourceTree = "<group>"; };
@@ -361,6 +377,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8037A3CB1FD68F660006BF65 /* libRNFS.a in Frameworks */,
 				809558431FD5A9A500AB89D7 /* libRNImagePicker.a in Frameworks */,
 				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
@@ -534,6 +551,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		8037A39D1FD68F560006BF65 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8037A3C71FD68F570006BF65 /* libRNFS.a */,
+				8037A3C91FD68F570006BF65 /* libRNFS.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		809558191FD5A98700AB89D7 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -545,6 +571,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */,
 				809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */,
 				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
@@ -781,6 +808,10 @@
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
 				},
 				{
+					ProductGroup = 8037A39D1FD68F560006BF65 /* Products */;
+					ProjectRef = 8037A39C1FD68F560006BF65 /* RNFS.xcodeproj */;
+				},
+				{
 					ProductGroup = 809558191FD5A98700AB89D7 /* Products */;
 					ProjectRef = 809558181FD5A98700AB89D7 /* RNImagePicker.xcodeproj */;
 				},
@@ -960,6 +991,20 @@
 			fileType = archive.ar;
 			path = libRCTLinking.a;
 			remoteRef = 78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8037A3C71FD68F570006BF65 /* libRNFS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNFS.a;
+			remoteRef = 8037A3C61FD68F570006BF65 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8037A3C91FD68F570006BF65 /* libRNFS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNFS.a;
+			remoteRef = 8037A3C81FD68F570006BF65 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		809558421FD5A98700AB89D7 /* libRNImagePicker.a */ = {

--- a/TestApp/ios/TestApp/Info.plist
+++ b/TestApp/ios/TestApp/Info.plist
@@ -57,7 +57,5 @@
     <string>$(PRODUCT_NAME) would like to use your camera</string>
     <key>NSPhotoLibraryAddUsageDescription</key>
     <string>$(PRODUCT_NAME) would like to save photos to your photo gallery</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>$(PRODUCT_NAME) would like to your microphone (for videos)</string>
 </dict>
 </plist>

--- a/TestApp/ios/TestApp/Info.plist
+++ b/TestApp/ios/TestApp/Info.plist
@@ -51,5 +51,13 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSPhotoLibraryUsageDescription</key>
+    <string>$(PRODUCT_NAME) would like access to your photo gallery</string>
+    <key>NSCameraUsageDescription</key>
+    <string>$(PRODUCT_NAME) would like to use your camera</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>$(PRODUCT_NAME) would like to save photos to your photo gallery</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>$(PRODUCT_NAME) would like to your microphone (for videos)</string>
 </dict>
 </plist>

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -16,6 +16,7 @@
     "react": "^16.0.0",
     "react-native": "^0.50.3",
     "react-native-dialog-component": "^0.2.17",
+    "react-native-image-picker": "^0.26.7",
     "react-navigation": "^1.0.0-beta.11"
   },
   "devDependencies": {

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -16,6 +16,7 @@
     "react": "^16.0.0",
     "react-native": "^0.50.3",
     "react-native-dialog-component": "^0.2.17",
+    "react-native-fs": "^2.8.5",
     "react-native-image-picker": "^0.26.7",
     "react-navigation": "^1.0.0-beta.11"
   },

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -15,6 +15,7 @@
     "appcenter-push": "file:appcenter-push-1.0.1.tgz",
     "react": "^16.0.0",
     "react-native": "^0.50.3",
+    "react-native-dialog-component": "^0.2.17",
     "react-navigation": "^1.0.0-beta.11"
   },
   "devDependencies": {

--- a/appcenter-crashes/Crashes.js
+++ b/appcenter-crashes/Crashes.js
@@ -121,8 +121,8 @@ const Helper = {
         if (!getErrorAttachmentsMethod) {
             return;
         }
-        filteredReports.forEach((report) => {
-            const attachments = getErrorAttachmentsMethod(report);
+        filteredReports.forEach(async (report) => {
+            const attachments = await getErrorAttachmentsMethod(report);
             AppCenterReactNativeCrashes.sendErrorAttachments(attachments, report.id);
         });
 

--- a/appcenter-crashes/Crashes.js
+++ b/appcenter-crashes/Crashes.js
@@ -123,12 +123,8 @@ const Helper = {
         }
         filteredReports.forEach((report) => {
             getErrorAttachmentsMethod(report)
-            .then(attachments => {
-                AppCenterReactNativeCrashes.sendErrorAttachments(attachments, report.id);
-            })
-            .catch(error => {
-                AppCenterLog.error(LOG_TAG, 'Crashes.getErrorAttachments: ' + error);
-            });
+            .then(attachments => AppCenterReactNativeCrashes.sendErrorAttachments(attachments, report.id))
+            .catch(error => AppCenterLog.error(LOG_TAG, 'Crashes.getErrorAttachments: ' + error));
         });
 
         // Prevent multipe calls if shouldAwaitUserConfirmation is false and user calling notifyUserConfirmation for some reason

--- a/appcenter-crashes/Crashes.js
+++ b/appcenter-crashes/Crashes.js
@@ -124,7 +124,7 @@ const Helper = {
         filteredReports.forEach((report) => {
             Promise.resolve(getErrorAttachmentsMethod(report))
             .then(attachments => AppCenterReactNativeCrashes.sendErrorAttachments(attachments, report.id))
-            .catch(error => AppCenterLog.error(LOG_TAG, `Crashes.sendErrorAttachments:${error}`));
+            .catch(error => AppCenterLog.error(LOG_TAG, `Could not send error attachments. Error: ${error}`));
         });
 
         // Prevent multipe calls if shouldAwaitUserConfirmation is false and user calling notifyUserConfirmation for some reason

--- a/appcenter-crashes/Crashes.js
+++ b/appcenter-crashes/Crashes.js
@@ -121,9 +121,14 @@ const Helper = {
         if (!getErrorAttachmentsMethod) {
             return;
         }
-        filteredReports.forEach(async (report) => {
-            const attachments = await getErrorAttachmentsMethod(report);
-            AppCenterReactNativeCrashes.sendErrorAttachments(attachments, report.id);
+        filteredReports.forEach((report) => {
+            getErrorAttachmentsMethod(report)
+            .then(attachments => {
+                AppCenterReactNativeCrashes.sendErrorAttachments(attachments, report.id);
+            })
+            .catch(error => {
+                AppCenterLog.error(LOG_TAG, 'Crashes.getErrorAttachments: ' + error);
+            });
         });
 
         // Prevent multipe calls if shouldAwaitUserConfirmation is false and user calling notifyUserConfirmation for some reason

--- a/appcenter-crashes/Crashes.js
+++ b/appcenter-crashes/Crashes.js
@@ -122,9 +122,9 @@ const Helper = {
             return;
         }
         filteredReports.forEach((report) => {
-            getErrorAttachmentsMethod(report)
+            Promise.resolve(getErrorAttachmentsMethod(report))
             .then(attachments => AppCenterReactNativeCrashes.sendErrorAttachments(attachments, report.id))
-            .catch(error => AppCenterLog.error(LOG_TAG, 'Crashes.getErrorAttachments: ' + error));
+            .catch(error => AppCenterLog.error(LOG_TAG, `Crashes.sendErrorAttachments:${error}`));
         });
 
         // Prevent multipe calls if shouldAwaitUserConfirmation is false and user calling notifyUserConfirmation for some reason


### PR DESCRIPTION
Please do not merge this yet, as there are some changes that need to be discussed.
This PR adds support to set text and binary attachments to test app. There is one major change in Crashes module, I've made getErrorAttachments function async so we could wait for attachments to be read from disk. 
```
async getErrorAttachments(report)
```
This caused this change in Crashes module:
```
filteredReports.forEach(async (report) => {
  const attachments = await getErrorAttachmentsMethod(report);
  AppCenterReactNativeCrashes.sendErrorAttachments(attachments, report.id);
});
```

If this solution is ok, I'll change other test apps too.