### PR TITLE
[TestApp] fix undefined bug in `getFileType` of ImagePicker

### DIFF
--- a/TestApp/CrashesScreen.js
+++ b/TestApp/CrashesScreen.js
@@ -168,11 +168,19 @@ export default class CrashesScreen extends Component {
     });
 
     function getFileName(response) {
-      return response.fileName !== null ? response.fileName : 'binary.jpeg';
+      let fileName = 'binary.jpeg';
+      if (response.fileName) {
+        fileName = response.fileName;
+      }
+      return fileName;
     }
 
     function getFileType(response) {
-      return response.type !== null ? response.type : 'image/jpeg';
+      let fileType = 'image/jpeg';
+      if (response.type) {
+        fileType = response.type;
+      }
+      return fileType;
     }
 
     function getFileSize(response) {


### PR DESCRIPTION
Fixing a bug in #179 

When [`response.type`](https://github.com/Microsoft/AppCenter-SDK-React-Native/pull/182/files#diff-33f5cd295c7df72cc86da8840788ac48L175) returns `undefined`, the file type is incorrectly set to undefined and thus crashing the test app.