### PR TITLE
fix an error in DemoApp post clone script

### DIFF
--- a/DemoApp/appcenter-post-clone.sh
+++ b/DemoApp/appcenter-post-clone.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 echo "Executing post clone script in `pwd`"
 echo $NPM_RC | base64 --decode > $APPCENTER_SOURCE_DIRECTORY/DemoApp/.npmrc
-./update-npm-packages.sh
 # Delete everything except DemoApp folder
 rm -rf ../appcenter* ../AppCenterReactNativeShared ../TestApp34 ../BrownfieldTestApp ../TestApp


### PR DESCRIPTION
`./update-npm-packages.sh` doesn't exist in DemoApp, this line was added by mistake and thus should be removed.