### PR TITLE
Let the script only check if the pod binary is available

### DIFF
--- a/appcenter-link-scripts/src/ios/index.js
+++ b/appcenter-link-scripts/src/ios/index.js
@@ -73,9 +73,6 @@ module.exports = {
     },
 
     addPodDeps(pods) {
-        if (process.platform !== 'darwin') {
-            return Promise.reject(new Error('Since you are not running on a Mac, CocoaPods installation steps will be skipped.'));
-        }
         if (!PodFile.isCocoaPodsInstalled()) {
             return Promise.reject(new Error('Could not find "pod" command. Is CocoaPods installed?'));
         }


### PR DESCRIPTION
From my experience there is no need to check the platform. If the `pod` binary is available the dependencies will be sucessfully added and installed. I am on a Linux machine, my project uses rbenv and cocoapods, and all is working when i try to link the libraries.