### PR TITLE
Add requiresMainQueueSetup to cure RN v0.52 warning

### DIFF
--- a/appcenter-crashes/ios/AppCenterReactNativeCrashes/AppCenterReactNativeCrashes.m
+++ b/appcenter-crashes/ios/AppCenterReactNativeCrashes/AppCenterReactNativeCrashes.m
@@ -70,7 +70,7 @@ RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+    return NO;
 }
 
 - (NSDictionary *)constantsToExport

--- a/appcenter-crashes/ios/AppCenterReactNativeCrashes/AppCenterReactNativeCrashes.m
+++ b/appcenter-crashes/ios/AppCenterReactNativeCrashes/AppCenterReactNativeCrashes.m
@@ -68,6 +68,11 @@ RCT_EXPORT_MODULE();
     return self;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (NSDictionary *)constantsToExport
 {
     return @{};

--- a/appcenter-push/ios/AppCenterReactNativePush/AppCenterReactNativePush.m
+++ b/appcenter-push/ios/AppCenterReactNativePush/AppCenterReactNativePush.m
@@ -46,7 +46,7 @@ RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+    return NO;
 }
 
 - (NSDictionary *)constantsToExport

--- a/appcenter-push/ios/AppCenterReactNativePush/AppCenterReactNativePush.m
+++ b/appcenter-push/ios/AppCenterReactNativePush/AppCenterReactNativePush.m
@@ -44,6 +44,11 @@ RCT_EXPORT_MODULE();
     return self;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (NSDictionary *)constantsToExport
 {
     return @{};


### PR DESCRIPTION
RN 0.52 warning that, because AppCenterReactNativeCrashes overrides 'init', it requires main queue setup, but does not implement 'requiresMainQueueSetup.' This PR implements 'requiresMainQueueSetup' and fixes the warning.