### PR TITLE
Turn off Eslint object destruction warnings

### DIFF
--- a/TestApp/.eslintrc
+++ b/TestApp/.eslintrc
@@ -30,6 +30,7 @@
         "no-useless-escape": 0,
         "import/no-dynamic-require": 0,
         "react/sort-comp": 0,
-        "import/extensions": 0
+        "import/extensions": 0,
+        "prefer-destructuring": [2, { "VariableDeclarator": { "array": false, "object": false }, "AssignmentExpression": { "array": true, "object": false }}]
     }
 }


### PR DESCRIPTION
https://eslint.org/docs/rules/prefer-destructuring Eslint rule only makes sense for es6 array assignment and make it less readable for objects.

This issue exists in master branch so fix it in master branch and then merge it back to develop.