### PR TITLE
Shorten log tags for Android bridge code

### DIFF
--- a/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/crashes/AppCenterReactNativeCrashesUtils.java
+++ b/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/crashes/AppCenterReactNativeCrashesUtils.java
@@ -15,7 +15,7 @@ import org.json.JSONStringer;
 import java.util.Collection;
 
 class AppCenterReactNativeCrashesUtils {
-    private static final String LOG_TAG = "AppCenterReactNativeCrashes";
+    private static final String LOG_TAG = "AppCenterCrashes";
 
     static void logError(String message) {
         Log.e(LOG_TAG, message);

--- a/appcenter-push/android/src/main/java/com/microsoft/appcenter/reactnative/push/AppCenterReactNativePushUtil.java
+++ b/appcenter-push/android/src/main/java/com/microsoft/appcenter/reactnative/push/AppCenterReactNativePushUtil.java
@@ -15,7 +15,7 @@ import java.util.Map.Entry;
 import org.json.JSONException;
 
 public class AppCenterReactNativePushUtil {
-    private static final String LOG_TAG = "AppCenterReactNativePush";
+    private static final String LOG_TAG = "AppCenterPush";
 
     public AppCenterReactNativePushUtil() {
     }

--- a/appcenter/android/src/main/java/com/microsoft/appcenter/reactnative/appcenter/ReactNativeUtils.java
+++ b/appcenter/android/src/main/java/com/microsoft/appcenter/reactnative/appcenter/ReactNativeUtils.java
@@ -31,7 +31,7 @@ import static com.facebook.react.bridge.ReadableType.String;
 
 public class ReactNativeUtils {
 
-    private static final String LOG_TAG = "AppCenterReactNative";
+    private static final String LOG_TAG = "AppCenter";
     private static final String DATE_KEY = "RNDate";
 
     private static final ThreadLocal<DateFormat> DATETIME_FORMAT = new ThreadLocal<DateFormat>() {


### PR DESCRIPTION
* This prevents gradle lint from failing as reported in #279.
* Align with Xamarin log tags which are the same as Native log tags.