### PR TITLE
Fix app center log include

### DIFF
--- a/appcenter/appcenter-log.js
+++ b/appcenter/appcenter-log.js
@@ -1,6 +1,6 @@
 const ReactNative = require('react-native');
 
-const { AppCenterReactNative } = ReactNative.NativeModules.AppCenterReactNative;
+const { AppCenterReactNative } = ReactNative.NativeModules;
 
 function format(tag, msg) {
     return `[${tag}] ${msg}`;


### PR DESCRIPTION
One of the reason we have issue #298 is because one import was broken. 
App Center logging was not working in a real app either.
It is not enough to fix the issue reported at #298 as Crashes and Push use event emitter on native module which needs to be mocked, but this fix is required as well.