### PR TITLE
Pretty print package.json

### DIFF
--- a/appcenter/test/SetupAppCenterMock.js
+++ b/appcenter/test/SetupAppCenterMock.js
@@ -27,7 +27,7 @@ module.exports = {
             } else if (packageJson.jest.setupFiles.indexOf(setupFileNamePath) === -1) {
                 packageJson.jest.setupFiles.push(setupFileNamePath);
             }
-            fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson));
+            fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, null, 2));
         }
     }
 };


### PR DESCRIPTION
When using yarn package.json is saved in a single line, this fixes it.