### PR TITLE
React/RCTDefines.h not found

### DIFF
--- a/appcenter-analytics/ios/appcenter-analytics.podspec
+++ b/appcenter-analytics/ios/appcenter-analytics.podspec
@@ -20,4 +20,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'AppCenterReactNativeShared'
   s.dependency 'AppCenter/Analytics'
+  s.dependency 'React'
 end

--- a/appcenter-crashes/ios/appcenter-crashes.podspec
+++ b/appcenter-crashes/ios/appcenter-crashes.podspec
@@ -20,5 +20,6 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
 
   s.dependency 'AppCenterReactNativeShared'
-  s.dependency 'AppCenter/Crashes'  
+  s.dependency 'AppCenter/Crashes'
+  s.dependency 'React'
 end

--- a/appcenter-push/ios/appcenter-push.podspec
+++ b/appcenter-push/ios/appcenter-push.podspec
@@ -20,5 +20,6 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
 
   s.dependency 'AppCenterReactNativeShared'
-  s.dependency 'AppCenter/Push'  
+  s.dependency 'AppCenter/Push'
+  s.dependency 'React'
 end

--- a/appcenter/ios/appcenter.podspec
+++ b/appcenter/ios/appcenter.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
 
   s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
   s.dependency 'AppCenterReactNativeShared'
+  s.dependency 'React'
 end


### PR DESCRIPTION
I'm having this issue: `React/RCTDefines.h not found` after upgrading CocoaPods to v 1.5.3
According to their [changelog](http://blog.cocoapods.org/CocoaPods-1.5.0/#further-improvements)

> CocoaPods will no longer add all header search paths for each xcconfig generated and instead, it only adds the header search paths for the dependencies of the pod.

So I tried adding React as a dependency in the podspec and that fixed the issue