### PR TITLE
Remove unused android support lib

### DIFF
--- a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+++ b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
@@ -33,11 +33,11 @@ public class MainApplication extends Application implements ReactApplication {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
             new AppCenterReactNativePushPackage(MainApplication.this),
+            new AppCenterReactNativeCrashesPackage(MainApplication.this, getResources().getString(R.string.appCenterCrashes_whenToSendCrashes)),
+            new AppCenterReactNativeAnalyticsPackage(MainApplication.this, getResources().getString(R.string.appCenterAnalytics_whenToEnableAnalytics)),
             new AppCenterReactNativePackage(MainApplication.this),
             new RNFSPackage(),
-            new ImagePickerPackage(),
-            new AppCenterReactNativeCrashesPackage(MainApplication.this, getResources().getString(R.string.appCenterCrashes_whenToSendCrashes)),
-            new AppCenterReactNativeAnalyticsPackage(MainApplication.this, getResources().getString(R.string.appCenterAnalytics_whenToEnableAnalytics))
+            new ImagePickerPackage()
       );
     }
   };

--- a/appcenter-analytics/android/build.gradle
+++ b/appcenter-analytics/android/build.gradle
@@ -17,7 +17,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.facebook.react:react-native:+'
     compile 'com.microsoft.appcenter:appcenter-analytics:1.5.1'
 

--- a/appcenter-crashes/android/build.gradle
+++ b/appcenter-crashes/android/build.gradle
@@ -17,7 +17,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.facebook.react:react-native:+'
     compile 'com.microsoft.appcenter:appcenter-crashes:1.5.1'
 

--- a/appcenter-push/android/build.gradle
+++ b/appcenter-push/android/build.gradle
@@ -17,7 +17,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.facebook.react:react-native:+'
     compile 'com.microsoft.appcenter:appcenter-push:1.5.1'
 

--- a/appcenter/android/build.gradle
+++ b/appcenter/android/build.gradle
@@ -17,7 +17,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.facebook.react:react-native:+'
     compile 'com.microsoft.appcenter:appcenter:1.5.1'
 


### PR DESCRIPTION
Our SDKs do not need "com.android.support:appcompat-v7:23.0.1" library as a dependency so remove it.