### PR TITLE
Fix bump wrapper sdk script

### DIFF
--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -64,27 +64,32 @@ cat ./appcenter-link-scripts/package.json | jq -r '.version = env.newVersion' > 
 # appcenter-push and AppCenterReactNativeShared projects
 
 gradleFileContent="$(cat ./appcenter/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
 gradleFileContent=`echo "${gradleFileContent/com.microsoft.appcenter.reactnative\:appcenter-react-native\:$oldWrapperSdkVersion/com.microsoft.appcenter.reactnative:appcenter-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./appcenter/android/build.gradle
 
 gradleFileContent="$(cat ./appcenter-crashes/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
 gradleFileContent=`echo "${gradleFileContent/com.microsoft.appcenter.reactnative\:appcenter-react-native\:$oldWrapperSdkVersion/com.microsoft.appcenter.reactnative:appcenter-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./appcenter-crashes/android/build.gradle
 
 gradleFileContent="$(cat ./appcenter-analytics/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
 gradleFileContent=`echo "${gradleFileContent/com.microsoft.appcenter.reactnative\:appcenter-react-native\:$oldWrapperSdkVersion/com.microsoft.appcenter.reactnative:appcenter-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./appcenter-analytics/android/build.gradle
 
 gradleFileContent="$(cat ./appcenter-push/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
 gradleFileContent=`echo "${gradleFileContent/com.microsoft.appcenter.reactnative\:appcenter-react-native\:$oldWrapperSdkVersion/com.microsoft.appcenter.reactnative:appcenter-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./appcenter-push/android/build.gradle
 
 gradleFileContent="$(cat ./AppCenterReactNativeShared/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
+gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./AppCenterReactNativeShared/android/build.gradle
 
 # Update wrapper sdk version in postlink.js for appcenter, appcenter-crashes, appcenter-analytics,

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -62,7 +62,7 @@ cat ./appcenter-link-scripts/package.json | jq -r '.version = env.newVersion' > 
 
 # Update wrapperk sdk version and android VersionCode in Android build.gradle for appcenter, appcenter-crashes, appcenter-analytics,
 # appcenter-push and AppCenterReactNativeShared projects
-#
+
 gradleFileContent="$(cat ./appcenter/android/build.gradle)"
 [[ ${gradleFileContent} =~ (versionName [\", \']${oldWrapperSdkVersion}[\", \']) ]]
 gradleFileContent=`echo "${gradleFileContent/${BASH_REMATCH[0]}/versionName '$newWrapperSdkVersion'}"`

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -62,34 +62,34 @@ cat ./appcenter-link-scripts/package.json | jq -r '.version = env.newVersion' > 
 
 # Update wrapperk sdk version and android VersionCode in Android build.gradle for appcenter, appcenter-crashes, appcenter-analytics,
 # appcenter-push and AppCenterReactNativeShared projects
-
+#
 gradleFileContent="$(cat ./appcenter/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
-gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
+[[ ${gradleFileContent} =~ (versionName [\", \']${oldWrapperSdkVersion}[\", \']) ]]
+gradleFileContent=`echo "${gradleFileContent/${BASH_REMATCH[0]}/versionName '$newWrapperSdkVersion'}"`
 gradleFileContent=`echo "${gradleFileContent/com.microsoft.appcenter.reactnative\:appcenter-react-native\:$oldWrapperSdkVersion/com.microsoft.appcenter.reactnative:appcenter-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./appcenter/android/build.gradle
 
 gradleFileContent="$(cat ./appcenter-crashes/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
-gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
+[[ ${gradleFileContent} =~ (versionName [\", \']${oldWrapperSdkVersion}[\", \']) ]]
+gradleFileContent=`echo "${gradleFileContent/${BASH_REMATCH[0]}/versionName '$newWrapperSdkVersion'}"`
 gradleFileContent=`echo "${gradleFileContent/com.microsoft.appcenter.reactnative\:appcenter-react-native\:$oldWrapperSdkVersion/com.microsoft.appcenter.reactnative:appcenter-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./appcenter-crashes/android/build.gradle
 
 gradleFileContent="$(cat ./appcenter-analytics/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
-gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
+[[ ${gradleFileContent} =~ (versionName [\", \']${oldWrapperSdkVersion}[\", \']) ]]
+gradleFileContent=`echo "${gradleFileContent/${BASH_REMATCH[0]}/versionName '$newWrapperSdkVersion'}"`
 gradleFileContent=`echo "${gradleFileContent/com.microsoft.appcenter.reactnative\:appcenter-react-native\:$oldWrapperSdkVersion/com.microsoft.appcenter.reactnative:appcenter-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./appcenter-analytics/android/build.gradle
 
 gradleFileContent="$(cat ./appcenter-push/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
-gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
+[[ ${gradleFileContent} =~ (versionName [\", \']${oldWrapperSdkVersion}[\", \']) ]]
+gradleFileContent=`echo "${gradleFileContent/${BASH_REMATCH[0]}/versionName '$newWrapperSdkVersion'}"`
 gradleFileContent=`echo "${gradleFileContent/com.microsoft.appcenter.reactnative\:appcenter-react-native\:$oldWrapperSdkVersion/com.microsoft.appcenter.reactnative:appcenter-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./appcenter-push/android/build.gradle
 
 gradleFileContent="$(cat ./AppCenterReactNativeShared/android/build.gradle)"
-gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName '$newWrapperSdkVersion'}"`
-gradleFileContent=`echo "${gradleFileContent/versionName \'$oldWrapperSdkVersion\'/versionName '$newWrapperSdkVersion'}"`
+[[ ${gradleFileContent} =~ (versionName [\", \']${oldWrapperSdkVersion}[\", \']) ]]
+gradleFileContent=`echo "${gradleFileContent/${BASH_REMATCH[0]}/versionName '$newWrapperSdkVersion'}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./AppCenterReactNativeShared/android/build.gradle
 
 # Update wrapper sdk version in postlink.js for appcenter, appcenter-crashes, appcenter-analytics,


### PR DESCRIPTION
Fixes bug in bump-wrapper-sdk-version script. It won't work if versionName is in single quotes. This PR makes it work with single and double quotes.