### PR TITLE
Set AppCenterReactNativeShared to 1.7.0 so `react-native link` works

### DIFF
--- a/appcenter-crashes/scripts/postlink.js
+++ b/appcenter-crashes/scripts/postlink.js
@@ -67,7 +67,7 @@ if (rnpmlink.ios.checkIfAppDelegateExists()) {
             return rnpmlink.ios.addPodDeps(
                 [
                     { pod: 'AppCenter/Crashes', version: '1.8.0' },
-                    { pod: 'AppCenterReactNativeShared', version: '1.8.0' } // in case people don't link appcenter (core)
+                    { pod: 'AppCenterReactNativeShared', version: '1.7.0' } // in case people don't link appcenter (core)
                 ],
                 { platform: 'ios', version: '9.0' }
             );


### PR DESCRIPTION
`AppCenterReactNativeShared` 1.8.0 does not seem to exist according to https://github.com/CocoaPods/Specs/tree/master/Specs/0/6/6/AppCenterReactNativeShared. `pod repo update` does not pull down changes either.

To get this to install in a project, I needed to manually update to 1.7.0 and run `pod install`.