### PR TITLE
Remove duplicates from build.gradle when using compile or implementation

### DIFF
--- a/appcenter-link-scripts/src/android/index.js
+++ b/appcenter-link-scripts/src/android/index.js
@@ -75,7 +75,7 @@ module.exports = {
         const gradlePath = 'android/app/build.gradle';
         let gradleContent = fs.readFileSync(gradlePath, 'utf-8');
         gradleContent.split('\n').forEach((line) => {
-            let match = line.match(/^\s*(compile|implementation) (project.*appcenter.*)$/);
+            const match = line.match(/^\s*(compile|implementation) (project.*appcenter.*)$/);
             if (match) {
                 if (lines[match[2]]) {
                     gradleContent = gradleContent.replace(line, '');

--- a/appcenter-link-scripts/src/android/index.js
+++ b/appcenter-link-scripts/src/android/index.js
@@ -75,11 +75,13 @@ module.exports = {
         const gradlePath = 'android/app/build.gradle';
         let gradleContent = fs.readFileSync(gradlePath, 'utf-8');
         gradleContent.split('\n').forEach((line) => {
-            if (lines[line]) {
-                gradleContent = gradleContent.replace(line, '');
-            }
-            if (line.match(/^\s*compile project.*appcenter.*$/)) {
-                lines[line] = true;
+            let match = line.match(/^\s*(compile|implementation) (project.*appcenter.*)$/);
+            if (match) {
+                if (lines[match[2]]) {
+                    gradleContent = gradleContent.replace(line, '');
+                } else {
+                    lines[match[2]] = true;
+                }
             }
         });
         gradleContent = gradleContent.replace(/\n\n\n/g, '\n\n');


### PR DESCRIPTION
A previous version of script removed duplicate dependencies only if they were linked with `compile` keyword. This version enhances this process taking into account dependencies that were linked with `implementation` keyword.