### PR TITLE
[TestApp] Display the right transmission target before selecting target from UI

### DIFF
--- a/TestApp/app/screens/TransmissionScreen.js
+++ b/TestApp/app/screens/TransmissionScreen.js
@@ -48,7 +48,7 @@ export default class TransmissionScreen extends Component {
               title: 'Select transmission target',
               data: [
                 {
-                  title: 'Select target token',
+                  title: this.state.targetToken.label,
                   valueChanged: option => this.setState({ targetToken: option }),
                   tokens: targetTokens
                 },


### PR DESCRIPTION
TestApp Transmission screen defaults to "Target Token 1" target before any target is selected from the UI, while displaying text "Select target token". This PR fixes this issue.