### PR TITLE
Update test apps to react-native@0.57.3 to make `jest` pass

### DIFF
--- a/DemoApp/package-lock.json
+++ b/DemoApp/package-lock.json
@@ -79,7 +79,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
-      "dev": true,
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -89,7 +88,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
       "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
         "esutils": "^2.0.0"
@@ -99,7 +97,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
       "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.0.0",
         "@babel/traverse": "^7.1.0",
@@ -110,7 +107,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
       "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -121,7 +117,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
-      "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -149,7 +144,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -200,7 +194,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
       "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -309,6 +302,11 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
       "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg=="
     },
+    "@babel/plugin-check-constants": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.38.tgz",
+      "integrity": "sha512-MjdGn/2sMLu0fnNFbkILut0OsegzRTeCOJ/uGHH88TwTXPzxONx2cTVJ36i3cTQXHMiIOUT3hX6HqzWM99Q6vA=="
+    },
     "@babel/plugin-external-helpers": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0.tgz",
@@ -334,7 +332,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0.tgz",
       "integrity": "sha512-cWhkx6SyjZ4caFOanoPmDNgQCuYYTmou4QXy886JsyLTw/vhWQbop2gLKsWyyswrJkKTB7fSNxVYbP/oEsoySA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-export-default-from": "^7.0.0"
@@ -388,7 +385,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
       "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -397,7 +393,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0.tgz",
       "integrity": "sha512-HNnjg/fFFbnuLAqr/Ocp1Y3GB4AjmXcu1xxn3ql3bS2kGrB/qi+Povshb8i3hOkE5jNozzh8r/0/lq1w8oOWbQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -414,7 +409,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
       "integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -455,7 +449,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.0.0.tgz",
       "integrity": "sha512-5fxmdqiAQVQTIS+KSvYeZuTt91wKtBTYi6JlIkvbQ6hmO+9fZE81ezxmMiFMIsxE7CdRSgzn7nQ1BChcvK9OpA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -464,7 +457,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
       "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -479,11 +471,18 @@
         "@babel/helper-remap-async-to-generator": "^7.1.0"
       }
     },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+      "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-block-scoping": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
       "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "lodash": "^4.17.10"
@@ -493,7 +492,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
       "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-define-map": "^7.1.0",
@@ -508,8 +506,7 @@
         "globals": {
           "version": "11.7.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-          "dev": true
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
         }
       }
     },
@@ -517,7 +514,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
       "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -526,7 +522,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz",
       "integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -535,7 +530,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
       "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -554,7 +548,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
       "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -563,7 +556,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
       "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -573,7 +565,14 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
       "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
-      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.0.0.tgz",
+      "integrity": "sha512-kgAGWcjVdflNPSaRb9rDPdGJ9/gF80VPmxx80gdKz6NSofHvxA2LofECQ+7GrDVzzH8zBJzTn1xlV4xnmWj/nw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -592,19 +591,34 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.0.0.tgz",
       "integrity": "sha512-Dag8mxx7/03oj8F8PkNso8GEMhwGfeT0TL6KfMsa9Brjx4IpwZVl3WBvEmYks8BMhPmrvM5NQ/tjaMbwEj5ijA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
+      "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
       }
     },
     "@babel/plugin-transform-parameters": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
       "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
-      "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.1.0",
         "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.0.0.tgz",
+      "integrity": "sha512-7HK6/jB4MLpwQUJQ3diaX0pbCRcoL9asJscQfU3D1HpDwYdrH6yAUKleUNFHFyGNYBI9UeJrS2Jpx2JhtPKu5g==",
+      "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
@@ -612,7 +626,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
       "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -621,7 +634,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
       "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-builder-react-jsx": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -632,7 +644,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz",
       "integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.0.0"
@@ -642,16 +653,25 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
-      "dev": true,
       "requires": {
         "regenerator-transform": "^0.13.3"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
+      "integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
       "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -660,7 +680,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
       "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -669,7 +688,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
       "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.0.0"
@@ -679,7 +697,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
       "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -689,7 +706,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.1.0.tgz",
       "integrity": "sha512-TOTtVeT+fekAesiCHnPz+PSkYSdOSLyLn42DI45nxg6iCdlQY6LIj/tYqpMB0y+YicoTUiYiXqF8rG6SKfhw6Q==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-typescript": "^7.0.0"
@@ -699,7 +715,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
       "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.0.0",
@@ -743,6 +758,21 @@
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
           }
+        }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
+      "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
@@ -901,7 +931,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -2970,8 +3000,7 @@
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domexception": {
       "version": "1.0.1",
@@ -3715,6 +3744,11 @@
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.18"
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.1.tgz",
+      "integrity": "sha512-IM+v/C40MNZWqsLErc32e0TyIk/NhkkQZL0QmjBh6zi1eXv0/GeVKmKmueQX7nn9SXQBQbTUcB8zuexIF3/88w=="
     },
     "fbjs-scripts": {
       "version": "0.8.3",
@@ -4484,7 +4518,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
       "requires": {
         "min-document": "^2.19.0",
         "process": "~0.5.1"
@@ -6557,7 +6590,7 @@
     },
     "kind-of": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
       "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
     },
     "klaw": {
@@ -6739,9 +6772,9 @@
       }
     },
     "metro": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.45.5.tgz",
-      "integrity": "sha512-GT6HF4aBEPzdpryM0qkR8yyfK+is3CxA5TjGjZ5mod6GYg5IZB+JyOLrhP/35PMO6rKCxvvyM5q6HNWRFBKjXQ==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.48.1.tgz",
+      "integrity": "sha512-7V+YOqfmgGhomdWAoD58zRQvPxUgBIo6b1YgcZULvh7yPPMo3tTkTvrzS2Qd2N3LFTysRQWzOlkb7O7jAV5FDw==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/generator": "^7.0.0",
@@ -6752,14 +6785,14 @@
         "@babel/types": "^7.0.0",
         "absolute-path": "^0.0.0",
         "async": "^2.4.0",
-        "babel-preset-fbjs": "2.3.0",
+        "babel-preset-fbjs": "^3.0.1",
         "chalk": "^1.1.1",
         "concat-stream": "^1.6.0",
         "connect": "^3.6.5",
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
         "eventemitter3": "^3.0.0",
-        "fbjs": "0.8.17",
+        "fbjs": "^1.0.0",
         "fs-extra": "^1.0.0",
         "graceful-fs": "^4.1.3",
         "image-size": "^0.6.0",
@@ -6769,16 +6802,18 @@
         "json-stable-stringify": "^1.0.1",
         "lodash.throttle": "^4.1.1",
         "merge-stream": "^1.0.1",
-        "metro-cache": "0.45.5",
-        "metro-config": "0.45.5",
-        "metro-core": "0.45.5",
-        "metro-minify-uglify": "0.45.5",
-        "metro-resolver": "0.45.5",
-        "metro-source-map": "0.45.5",
+        "metro-cache": "0.48.1",
+        "metro-config": "0.48.1",
+        "metro-core": "0.48.1",
+        "metro-minify-uglify": "0.48.1",
+        "metro-react-native-babel-preset": "0.48.1",
+        "metro-resolver": "0.48.1",
+        "metro-source-map": "0.48.1",
         "mime-types": "2.1.11",
         "mkdirp": "^0.5.1",
         "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.0",
+        "react-transform-hmr": "^1.0.4",
         "resolve": "^1.5.0",
         "rimraf": "^2.5.4",
         "serialize-error": "^2.1.0",
@@ -6792,6 +6827,116 @@
         "yargs": "^9.0.0"
       },
       "dependencies": {
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+          "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+        },
+        "babel-preset-fbjs": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.0.1.tgz",
+          "integrity": "sha512-Fc0t7v8T1tBwv5AVyDDZEnS3T7OQ97qV0XawVZg1ouarlM9xCHL994C5tU8TBIKPk3yZXG+SaEM1YQcx/yLlcg==",
+          "requires": {
+            "@babel/plugin-check-constants": "^7.0.0-beta.38",
+            "@babel/plugin-proposal-class-properties": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-syntax-class-properties": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.0.0",
+            "@babel/plugin-syntax-jsx": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-object-super": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-property-literals": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+          }
+        },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "metro-babel7-plugin-react-transform": {
+          "version": "0.48.1",
+          "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.48.1.tgz",
+          "integrity": "sha512-b39Sowwzp0bqitbS3NkF5fzcuoT6vpLqj6Su7xgfCyW5EmYpvxunK7HwMSoZagAIpbD0H6r+iw+L2Ib1EEWfWw==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0"
+          }
+        },
+        "metro-react-native-babel-preset": {
+          "version": "0.48.1",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.48.1.tgz",
+          "integrity": "sha512-euJ0MOyBYTa76kQNbly6An9FNpu9BqxfkXhKtD8hWZxo5dxIAk25AmoWfXU2OHj7PogG/u0Ndo3tmhZZ2NWYvA==",
+          "requires": {
+            "@babel/plugin-proposal-class-properties": "^7.0.0",
+            "@babel/plugin-proposal-export-default-from": "^7.0.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-export-default-from": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-object-assign": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-runtime": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typescript": "^7.0.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "@babel/template": "^7.0.0",
+            "metro-babel7-plugin-react-transform": "0.48.1",
+            "react-transform-hmr": "^1.0.4"
+          }
+        },
         "mime-db": {
           "version": "1.23.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
@@ -6808,9 +6953,9 @@
       }
     },
     "metro-babel-register": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.45.5.tgz",
-      "integrity": "sha512-XD2jYjf4+M8JNsEYDhXcOcfmT8EpIBuJSEBOC8zT7dMJoUok1SOavz+O1oAkgLKYzjHvi9/w/MK94PBki+4p+Q==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.48.1.tgz",
+      "integrity": "sha512-bSjMAD16vpyHRWeMJ6CXvhWbFbiW58YXhA9zgRbFBdxOcJPbkhj6HEX+FlxTlr2O0MNY27/4U96MFXTcRWcZhQ==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
@@ -6843,47 +6988,72 @@
       }
     },
     "metro-cache": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.45.5.tgz",
-      "integrity": "sha512-FET/g13AFMkunCHnh6a6SNTmWRMQL8kl/sV0zqEIKSUD7pgTbgbsR5ZxcMnpeUjcJC5X7SQZC9+UcON1k0tDRw==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.48.1.tgz",
+      "integrity": "sha512-Nq1RQ7SkhVKKO/uWKzc6JtvDm0JJD/kDsoIQNR2Db37fNlyGxij0FoYRNOX3BOnyhz0NG8kU1pz0qH43bPQ5rg==",
       "requires": {
         "jest-serializer": "23.0.1",
-        "metro-core": "0.45.5",
+        "metro-core": "0.48.1",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4"
       }
     },
     "metro-config": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.45.5.tgz",
-      "integrity": "sha512-IUsRO7uDtoFhUebiwBhm4FzO4bJU+gL0kEj51ZV62iAoSesMmucC2hpq0K1bEMZyE5ZCM4KvrQOsvUkF+3xUaw==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.48.1.tgz",
+      "integrity": "sha512-pqdbDHUtoQPfWiL8h3x/cN5Q8w/sPt5/UaXk4oIzalU+ooEh0Hi9w10wJHKVRtWzD27o828O04En51C9eEDY5g==",
       "requires": {
         "cosmiconfig": "^5.0.5",
-        "metro": "0.45.5",
-        "metro-cache": "0.45.5",
-        "metro-core": "0.45.5"
+        "metro": "0.48.1",
+        "metro-cache": "0.48.1",
+        "metro-core": "0.48.1",
+        "pretty-format": "^23.4.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "pretty-format": {
+          "version": "23.6.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+          "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        }
       }
     },
     "metro-core": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.45.5.tgz",
-      "integrity": "sha512-ugANHIwVje1FJ2Ih05LZi70Ynok9BWn8FN3WXoH1eISoNK+AfyrKS/qwmuQ1K3tY221MoaGr+LnvzHUUGmb8ZA==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.48.1.tgz",
+      "integrity": "sha512-uctosjP4imHThHlD5hAt0Yg7tiRLmY3GlU4VaIs0YH2i82yI56b93RtTCI1ACWhL7LUuttSVpPXCBN3ERTe+KA==",
       "requires": {
         "jest-haste-map": "23.5.0",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.45.5",
+        "metro-resolver": "0.48.1",
         "wordwrap": "^1.0.0"
       }
     },
     "metro-memory-fs": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro-memory-fs/-/metro-memory-fs-0.45.5.tgz",
-      "integrity": "sha512-Ca2D8EL6frKSMyUia7FzRBzJsnb0ubQ02mBBxio/vlVAAbVZ6Keka4AfXpmhoK2VV9t0HyANfQOPDY0LDWS6tA=="
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-memory-fs/-/metro-memory-fs-0.48.1.tgz",
+      "integrity": "sha512-ASbRBpmfRraFilm5o5gdY9X0DQAmkvCgAHDunCo0J2vlQ730VbuhhR67pVRmRr5oXXmDdEIYUkJSIqzP0Q+UKQ=="
     },
     "metro-minify-uglify": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.45.5.tgz",
-      "integrity": "sha512-gevI+yqgTXjhqLdqKdMQbL3YBtyOy4qUdFpzyWBkV1Z+l2Rsd58coNUko6og6GC/jHbtCG1eSyBKLuL9q20LAQ==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.48.1.tgz",
+      "integrity": "sha512-8htDNs3dil5CopLnMrE6SGjMGg44KB+omE3ZyTNSWXbmZl8aG3spl+xpSJyvkIQrSFNSCzMVZ8V+lDJDwKJ/zg==",
       "requires": {
         "uglify-es": "^3.1.9"
       }
@@ -6931,17 +7101,17 @@
       }
     },
     "metro-resolver": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.45.5.tgz",
-      "integrity": "sha512-RVM9BvIkl8W7m1qS33gl9SeFBVPnHmlTzskcAivujNPUHUgdxRof5e2yPOXB0HM9dMGvLpFZ7R+TfG0I4Jb1fQ==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.48.1.tgz",
+      "integrity": "sha512-d28ki5RTRUPFNQVJEgiMx3Zr81NlxOm1mKgaBx93Alyy2ZZ1Gvs25olZHwHgKPsRTgCqg5kgImkIHtjP2j8BdQ==",
       "requires": {
         "absolute-path": "^0.0.0"
       }
     },
     "metro-source-map": {
-      "version": "0.45.5",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.45.5.tgz",
-      "integrity": "sha512-8IJFSHZbIS3KMVWaC+sFtiGhmQRFXGxgYgzIjVXiGJe8bJRBV7u4pzf8PsJjYELIjwbW9fhWe//d6j0whVmUHQ==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.48.1.tgz",
+      "integrity": "sha512-6+YSKB3zRLGA39I0G/wfPizf1HPlrnmeX70E1vvH0G1HVD/ko5dqjJgH4vlr71Za9xYZLSuaXoQmmgkcf6at4w==",
       "requires": {
         "source-map": "^0.5.6"
       }
@@ -7011,7 +7181,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -7348,7 +7517,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "requires": {
         "object-assign": "^4.0.1"
@@ -7633,8 +7802,7 @@
     "process": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-      "dev": true
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -7659,7 +7827,6 @@
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-      "dev": true,
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.3.1",
@@ -7726,14 +7893,14 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "react": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.5.0.tgz",
-      "integrity": "sha512-nw/yB/L51kA9PsAy17T1JrzzGRk+BlFCJwFF7p+pwVxgqwPjYNeZEkkH7LXn9dmflolrYMXLWMTkQ77suKPTNQ==",
+      "version": "16.6.0-alpha.8af6728",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.6.0-alpha.8af6728.tgz",
+      "integrity": "sha512-W5NwSMey/JjF4wdeB7ek/+qG4bJJhgM1O/NaHvhUswgJxBMcFLUroODPELbq6IVolgua+anEirtOCx3fMXHZjw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "schedule": "^0.3.0"
+        "scheduler": "^0.10.0-alpha.8af6728"
       },
       "dependencies": {
         "prop-types": {
@@ -7755,13 +7922,12 @@
     "react-deep-force-update": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz",
-      "integrity": "sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA==",
-      "dev": true
+      "integrity": "sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA=="
     },
     "react-devtools-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.3.4.tgz",
-      "integrity": "sha512-6lsBDRInT9jU8Ya8bnKWJSsnaGg/xk1ZSfvhc/dHc3n2CUTMfGlqm2tGeZQ9WEoe0Y2K7Lg90Kvb1E8anLePaQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.4.0.tgz",
+      "integrity": "sha512-yV3LLhoRwbfcQyVPNwb1EZ9W7CGu+kX2EqyZ3Cl5C+cbXcb6FJ3YSeeBt9BQB+hjyjRMBjQSKqnpPS6OMSEUow==",
       "requires": {
         "shell-quote": "^1.6.1",
         "ws": "^3.3.1"
@@ -7785,9 +7951,9 @@
       }
     },
     "react-is": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
-      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==",
+      "version": "16.6.0-alpha.8af6728",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0-alpha.8af6728.tgz",
+      "integrity": "sha512-F65AeMavskvRglteO7dC0Nvq3Br1ESnpCOG5M6fenQX52Uhpt6eCI0vL3ICM/hnVhIOQY2fwnSWtST33OlgxVA==",
       "dev": true
     },
     "react-lifecycles-compat": {
@@ -7796,10 +7962,11 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-native": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.57.0.tgz",
-      "integrity": "sha512-L/bPmqWsei1EyHdikg/jOdl9unVyrehmkoNlkGCl3Y5Zr7KGE36j+DOL6M0OqpGVkWIXJ5Jzk/ttea/X3edVVg==",
+      "version": "0.57.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.57.3.tgz",
+      "integrity": "sha512-FmJQdGjo0rEfEYbw+dhMPn2P/vDpvPebAwL3YDaQ/iYSi+IGPNHdepEaDpU1vfFOAnxrh3BlfACC+RsoeQ3SWw==",
       "requires": {
+        "@babel/runtime": "^7.0.0",
         "absolute-path": "^0.0.0",
         "art": "^0.10.0",
         "base64-js": "^1.1.2",
@@ -7814,17 +7981,17 @@
         "errorhandler": "^1.5.0",
         "escape-string-regexp": "^1.0.5",
         "event-target-shim": "^1.0.5",
-        "fbjs": "0.8.17",
+        "fbjs": "^1.0.0",
         "fbjs-scripts": "^0.8.1",
         "fs-extra": "^1.0.0",
         "glob": "^7.1.1",
         "graceful-fs": "^4.1.3",
         "inquirer": "^3.0.6",
         "lodash": "^4.17.5",
-        "metro": "^0.45.0",
-        "metro-babel-register": "^0.45.0",
-        "metro-core": "^0.45.0",
-        "metro-memory-fs": "^0.45.0",
+        "metro": "^0.48.1",
+        "metro-babel-register": "^0.48.1",
+        "metro-core": "^0.48.1",
+        "metro-memory-fs": "^0.48.1",
         "mime": "^1.3.4",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
@@ -7839,7 +8006,7 @@
         "promise": "^7.1.1",
         "prop-types": "^15.5.8",
         "react-clone-referenced-element": "^1.0.1",
-        "react-devtools-core": "3.3.4",
+        "react-devtools-core": "^3.4.0",
         "react-timer-mixin": "^0.13.2",
         "regenerator-runtime": "^0.11.0",
         "rimraf": "^2.5.4",
@@ -7879,6 +8046,11 @@
             "restore-cursor": "^2.0.0"
           }
         },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
         "external-editor": {
           "version": "2.2.0",
           "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
@@ -7887,6 +8059,21 @@
             "chardet": "^0.4.0",
             "iconv-lite": "^0.4.17",
             "tmp": "^0.0.33"
+          }
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
           }
         },
         "figures": {
@@ -7964,15 +8151,6 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "requires": {
             "mimic-fn": "^1.0.0"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
           }
         },
         "restore-cursor": {
@@ -8199,22 +8377,33 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
       "integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
-      "dev": true,
       "requires": {
         "lodash": "^4.6.1",
         "react-deep-force-update": "^1.0.0"
       }
     },
     "react-test-renderer": {
-      "version": "16.3.1",
-      "resolved": "http://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.3.1.tgz",
-      "integrity": "sha512-emEcIPUowMjT5EQ+rrb0FAwVCzuJ+LKDweoYDh073v2/jHxrBDPUk8nzI5dofG3R+140+Bb9TMcT2Ez5OP6pQw==",
+      "version": "16.6.0-alpha.8af6728",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.6.0-alpha.8af6728.tgz",
+      "integrity": "sha512-42RB1hvEjVuJGrGddGqVj1obs9NhWiuijkz+qsuY0qRzF0ygD5xg4eRdm0H4YNtkp+332g6OWO9O2ussu67cFQ==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0",
-        "react-is": "^16.3.1"
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0-alpha.8af6728",
+        "scheduler": "^0.10.0-alpha.8af6728"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-timer-mixin": {
@@ -8226,7 +8415,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
       "integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
-      "dev": true,
       "requires": {
         "global": "^4.3.0",
         "react-proxy": "^1.1.7"
@@ -8277,14 +8465,12 @@
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerate-unicode-properties": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
-      "dev": true,
       "requires": {
         "regenerate": "^1.4.0"
       }
@@ -8298,7 +8484,6 @@
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
       "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
-      "dev": true,
       "requires": {
         "private": "^0.1.6"
       }
@@ -8349,7 +8534,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
-      "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^7.0.0",
@@ -8362,14 +8546,12 @@
     "regjsgen": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
-      "dev": true
+      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
     },
     "regjsparser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
-      "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
       },
@@ -8377,8 +8559,7 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
@@ -8898,11 +9079,12 @@
       "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
     },
-    "schedule": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.3.0.tgz",
-      "integrity": "sha512-20+1KVo517sR7Nt+bYBN8a+bEJDKLPEx7Ohtts1kX05E4/HY53YUNuhfkVNItmWAnBYHcpG9vsd2/CJxG+aPCQ==",
+    "scheduler": {
+      "version": "0.10.0-alpha.f47a958",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.10.0-alpha.f47a958.tgz",
+      "integrity": "sha512-GVz1gvEU4JhqqiLB+DhRwd17sqKCmVsmdrsDoKMOIRCu0z+qYhimF6PvA3q61BgCqHDWJZiAidom6saiE8ZrOQ==",
       "requires": {
+        "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
     },
@@ -8945,7 +9127,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serve-static": {
@@ -9850,14 +10032,12 @@
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "dev": true
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "dev": true,
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
         "unicode-property-aliases-ecmascript": "^1.0.4"
@@ -9866,14 +10046,12 @@
     "unicode-match-property-value-ecmascript": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
-      "dev": true
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
-      "dev": true
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
     },
     "union-value": {
       "version": "1.0.0",

--- a/DemoApp/package.json
+++ b/DemoApp/package.json
@@ -12,8 +12,8 @@
     "appcenter-analytics": "^1.8.1",
     "appcenter-crashes": "^1.8.1",
     "appcenter-push": "^1.8.1",
-    "react": "16.5.0",
-    "react-native": "^0.57.0",
+    "react": "16.6.0-alpha.8af6728",
+    "react-native": "0.57.3",
     "react-native-dialog-input": "^1.0.4",
     "react-native-fs": "^2.9.12",
     "react-native-image-picker": "^0.26.7",
@@ -35,7 +35,7 @@
     "jest": "22.4.3",
     "metro-react-native-babel-preset": "^0.45.3",
     "prop-types": "15.6.0",
-    "react-test-renderer": "16.3.1"
+    "react-test-renderer": "16.6.0-alpha.8af6728"
   },
   "jest": {
     "preset": "react-native",

--- a/TestApp/package-lock.json
+++ b/TestApp/package-lock.json
@@ -352,162 +352,6 @@
         "@babel/template": "^7.1.0",
         "@babel/traverse": "^7.1.0",
         "@babel/types": "^7.0.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
-          "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
-          "requires": {
-            "@babel/types": "^7.0.0",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-annotate-as-pure": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-          "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-          "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.0.0",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.1.0",
-            "@babel/types": "^7.0.0",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        }
       }
     },
     "@babel/helper-replace-supers": {
@@ -547,154 +391,6 @@
         "@babel/template": "^7.1.0",
         "@babel/traverse": "^7.1.0",
         "@babel/types": "^7.0.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
-          "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
-          "requires": {
-            "@babel/types": "^7.0.0",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-          "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.0.0",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.1.0",
-            "@babel/types": "^7.0.0",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        }
       }
     },
     "@babel/highlight": {
@@ -750,6 +446,11 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
       "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg=="
     },
+    "@babel/plugin-check-constants": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.38.tgz",
+      "integrity": "sha512-MjdGn/2sMLu0fnNFbkILut0OsegzRTeCOJ/uGHH88TwTXPzxONx2cTVJ36i3cTQXHMiIOUT3hX6HqzWM99Q6vA=="
+    },
     "@babel/plugin-external-helpers": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0.tgz",
@@ -769,6 +470,15 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-replace-supers": "^7.1.0",
         "@babel/plugin-syntax-class-properties": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-export-default-from": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0.tgz",
+      "integrity": "sha512-cWhkx6SyjZ4caFOanoPmDNgQCuYYTmou4QXy886JsyLTw/vhWQbop2gLKsWyyswrJkKTB7fSNxVYbP/oEsoySA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-export-default-from": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -835,13 +545,14 @@
       "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
-        }
+      }
+    },
+    "@babel/plugin-syntax-export-default-from": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0.tgz",
+      "integrity": "sha512-HNnjg/fFFbnuLAqr/Ocp1Y3GB4AjmXcu1xxn3ql3bS2kGrB/qi+Povshb8i3hOkE5jNozzh8r/0/lq1w8oOWbQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-flow": {
@@ -930,36 +641,14 @@
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.1.0"
-      },
-      "dependencies": {
-        "@babel/helper-module-imports": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-          "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
-        },
-        "@babel/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        }
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+      "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -1052,6 +741,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.0.0.tgz",
+      "integrity": "sha512-kgAGWcjVdflNPSaRb9rDPdGJ9/gF80VPmxx80gdKz6NSofHvxA2LofECQ+7GrDVzzH8zBJzTn1xlV4xnmWj/nw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-modules-commonjs": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
@@ -1070,6 +767,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
+      "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
+      }
+    },
     "@babel/plugin-transform-parameters": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
@@ -1077,6 +783,14 @@
       "requires": {
         "@babel/helper-call-delegate": "^7.1.0",
         "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.0.0.tgz",
+      "integrity": "sha512-7HK6/jB4MLpwQUJQ3diaX0pbCRcoL9asJscQfU3D1HpDwYdrH6yAUKleUNFHFyGNYBI9UeJrS2Jpx2JhtPKu5g==",
+      "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
@@ -1113,6 +827,17 @@
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
       "requires": {
         "regenerator-transform": "^0.13.3"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
+      "integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -1205,6 +930,21 @@
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
           }
+        }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
+      "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
@@ -1416,7 +1156,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -1453,7 +1193,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -1783,21 +1523,21 @@
     },
     "appcenter": {
       "version": "file:appcenter-1.8.1.tgz",
-      "integrity": "sha512-8MmGRhXcL8mNuS9Wb76XJdJfK6U+4DXYiPb31RhKrav5QAwPSpawX6wG+akP/2BlLF/vgw8RUlyQFSad82VaxA==",
+      "integrity": "sha512-hUKIYClxBa/slVRliS8HuzbyNtz478SazTeT5I/2leYCzH02dW4AD9EwoYR70I/GGqaakbG/twvoJ+jfg36sbg==",
       "requires": {
         "appcenter-link-scripts": "1.8.1"
       }
     },
     "appcenter-analytics": {
       "version": "file:appcenter-analytics-1.8.1.tgz",
-      "integrity": "sha512-V+0nMCY5Lk3hr+4a+Fj3MOEhKgnoLrcxVogPor9oCxI/6UQQWXOVtIaHUEPdRyORwFPZ4AMtRvzilm2MtD/YRQ==",
+      "integrity": "sha512-gG2YZMfduXTz38aAY0Hw4A9M0s1Eekqo1jtyAog9Mn9ofTOQtGnL28THaoR/28KoPe8ag5GX8hT/ExXkksqnLQ==",
       "requires": {
         "appcenter": "1.8.1"
       }
     },
     "appcenter-crashes": {
       "version": "file:appcenter-crashes-1.8.1.tgz",
-      "integrity": "sha512-k1fEc5xiLDIeDtDApmw/Y2Ew9qkOilfbISYOa7sZM8bd1PzRf5aEah1GSAedBqdtS04hIBImvG4TA6m7IKxWDQ==",
+      "integrity": "sha512-BjF7NQ6FXPtIYNM87RCAcHCCzQg0qFNRhF9UEf5NggyLX00R4aPxQVDG6u+OSUv41PJuIGazwnqpw7AK1xB1FA==",
       "requires": {
         "appcenter": "1.8.1"
       }
@@ -1817,7 +1557,7 @@
     },
     "appcenter-push": {
       "version": "file:appcenter-push-1.8.1.tgz",
-      "integrity": "sha512-yqhH1cXg7I3b/dKZnauxKMuYWOQQS2iW3uV/xFyzk8ofW3nrHp+lCRw6pQgETA3fBn7GyxL/ndfWaxMP4x21uA==",
+      "integrity": "sha512-O2ukx6JGy7M7FCpxTEbjL79FAHCPU/QO/PyGRlDAcBCrH/umaOd7VuODHx37eOKCmGOjVzkj86vlNExcqEPKsA==",
       "requires": {
         "appcenter": "1.8.1"
       }
@@ -2065,7 +1805,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
           "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
           "dev": true,
           "requires": {
@@ -2074,7 +1814,7 @@
         },
         "@babel/generator": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
           "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
           "dev": true,
           "requires": {
@@ -2087,7 +1827,7 @@
         },
         "@babel/helper-function-name": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
           "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
           "dev": true,
           "requires": {
@@ -2098,7 +1838,7 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
           "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
           "dev": true,
           "requires": {
@@ -2107,7 +1847,7 @@
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
           "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
           "dev": true,
           "requires": {
@@ -2116,7 +1856,7 @@
         },
         "@babel/highlight": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
           "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
           "dev": true,
           "requires": {
@@ -2127,7 +1867,7 @@
         },
         "@babel/template": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
           "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
           "dev": true,
           "requires": {
@@ -2139,7 +1879,7 @@
         },
         "@babel/traverse": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
           "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
           "dev": true,
           "requires": {
@@ -2157,7 +1897,7 @@
         },
         "@babel/types": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
           "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
@@ -2177,7 +1917,7 @@
         },
         "babylon": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
           "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
           "dev": true
         },
@@ -2378,7 +2118,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -2396,22 +2136,22 @@
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -2864,18 +2604,11 @@
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "basic-auth": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
-      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        }
+        "safe-buffer": "5.1.2"
       }
     },
     "bcrypt-pbkdf": {
@@ -3033,7 +2766,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -3675,7 +3408,7 @@
     },
     "eslint": {
       "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
@@ -3771,7 +3504,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -4178,7 +3911,7 @@
     },
     "expect": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
       "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
       "dev": true,
       "requires": {
@@ -4216,7 +3949,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "requires": {
         "extend": "^3.0.0",
@@ -4287,6 +4020,11 @@
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.9"
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.1.tgz",
+      "integrity": "sha512-IM+v/C40MNZWqsLErc32e0TyIk/NhkkQZL0QmjBh6zi1eXv0/GeVKmKmueQX7nn9SXQBQbTUcB8zuexIF3/88w=="
     },
     "fbjs-scripts": {
       "version": "0.8.3",
@@ -5337,7 +5075,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -5414,7 +5152,7 @@
     },
     "inquirer": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.1.2.tgz",
       "integrity": "sha1-rDul8GuOcpGr2fIpEsA/Cc/i3R8=",
       "requires": {
         "ansi-escapes": "^1.1.0",
@@ -5863,7 +5601,7 @@
     },
     "jest": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
       "integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
       "dev": true,
       "requires": {
@@ -6144,7 +5882,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -6165,7 +5903,7 @@
     },
     "jest-diff": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
       "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
       "dev": true,
       "requires": {
@@ -6203,7 +5941,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -6340,7 +6078,7 @@
     },
     "jest-leak-detector": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
       "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
       "dev": true,
       "requires": {
@@ -6364,7 +6102,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -6376,7 +6114,7 @@
     },
     "jest-matcher-utils": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
       "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
       "dev": true,
       "requires": {
@@ -6413,7 +6151,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -6490,7 +6228,7 @@
     },
     "jest-resolve": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
       "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
       "dev": true,
       "requires": {
@@ -6531,7 +6269,7 @@
     },
     "jest-resolve-dependencies": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
       "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
       "dev": true,
       "requires": {
@@ -6838,7 +6576,7 @@
     },
     "jest-snapshot": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
       "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
       "dev": true,
       "requires": {
@@ -6878,7 +6616,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -6996,7 +6734,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -7144,7 +6882,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -7178,7 +6916,7 @@
     },
     "kind-of": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
       "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
     },
     "klaw": {
@@ -7350,55 +7088,27 @@
       }
     },
     "metro": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.45.3.tgz",
-      "integrity": "sha512-OBqd8MIKe6NQ5gLciGAbvFbgg0mqPoxaeZW/PxvHHk4fgxcrCM3MMc/iWGPo4lY8b2Aet8n+9DAf9ApjGeObOA==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.48.1.tgz",
+      "integrity": "sha512-7V+YOqfmgGhomdWAoD58zRQvPxUgBIo6b1YgcZULvh7yPPMo3tTkTvrzS2Qd2N3LFTysRQWzOlkb7O7jAV5FDw==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/generator": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.0.0",
         "@babel/parser": "^7.0.0",
         "@babel/plugin-external-helpers": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.0.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.0.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-        "@babel/plugin-transform-for-of": "^7.0.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-object-assign": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-template-literals": "^7.0.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/register": "^7.0.0",
         "@babel/template": "^7.0.0",
         "@babel/traverse": "^7.0.0",
         "@babel/types": "^7.0.0",
         "absolute-path": "^0.0.0",
         "async": "^2.4.0",
-        "babel-preset-fbjs": "2.3.0",
+        "babel-preset-fbjs": "^3.0.1",
         "chalk": "^1.1.1",
         "concat-stream": "^1.6.0",
         "connect": "^3.6.5",
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
         "eventemitter3": "^3.0.0",
-        "fbjs": "0.8.17",
+        "fbjs": "^1.0.0",
         "fs-extra": "^1.0.0",
         "graceful-fs": "^4.1.3",
         "image-size": "^0.6.0",
@@ -7406,18 +7116,15 @@
         "jest-haste-map": "23.5.0",
         "jest-worker": "23.2.0",
         "json-stable-stringify": "^1.0.1",
-        "json5": "^0.4.0",
         "lodash.throttle": "^4.1.1",
         "merge-stream": "^1.0.1",
-        "metro-babel-register": "0.45.3",
-        "metro-babel7-plugin-react-transform": "0.45.3",
-        "metro-cache": "0.45.3",
-        "metro-config": "0.45.3",
-        "metro-core": "0.45.3",
-        "metro-minify-uglify": "0.45.3",
-        "metro-react-native-babel-preset": "0.45.3",
-        "metro-resolver": "0.45.3",
-        "metro-source-map": "0.45.3",
+        "metro-cache": "0.48.1",
+        "metro-config": "0.48.1",
+        "metro-core": "0.48.1",
+        "metro-minify-uglify": "0.48.1",
+        "metro-react-native-babel-preset": "0.48.1",
+        "metro-resolver": "0.48.1",
+        "metro-source-map": "0.48.1",
         "mime-types": "2.1.11",
         "mkdirp": "^0.5.1",
         "node-fetch": "^2.2.0",
@@ -7436,510 +7143,58 @@
         "yargs": "^9.0.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+          "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+        },
+        "babel-preset-fbjs": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.0.1.tgz",
+          "integrity": "sha512-Fc0t7v8T1tBwv5AVyDDZEnS3T7OQ97qV0XawVZg1ouarlM9xCHL994C5tU8TBIKPk3yZXG+SaEM1YQcx/yLlcg==",
           "requires": {
-            "@babel/highlight": "^7.0.0"
+            "@babel/plugin-check-constants": "^7.0.0-beta.38",
+            "@babel/plugin-proposal-class-properties": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-syntax-class-properties": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.0.0",
+            "@babel/plugin-syntax-jsx": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-object-super": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-property-literals": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
           }
         },
-        "@babel/generator": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
-          "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
-          "requires": {
-            "@babel/types": "^7.0.0",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-annotate-as-pure": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-          "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-builder-binary-assignment-operator-visitor": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-          "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
-          "requires": {
-            "@babel/helper-explode-assignable-expression": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-builder-react-jsx": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
-          "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
-          "requires": {
-            "@babel/types": "^7.0.0",
-            "esutils": "^2.0.0"
-          }
-        },
-        "@babel/helper-call-delegate": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
-          "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
-          "requires": {
-            "@babel/helper-hoist-variables": "^7.0.0",
-            "@babel/traverse": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-define-map": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
-          "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
-          "requires": {
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/types": "^7.0.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/helper-explode-assignable-expression": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-          "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
-          "requires": {
-            "@babel/traverse": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
-          "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-          "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-          "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
-          "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/helper-simple-access": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/helper-optimise-call-expression": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-          "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
-        },
-        "@babel/helper-regex": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-          "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
-          "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.0.0",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/traverse": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-          "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
-          "requires": {
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-          "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-              "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
-        "@babel/plugin-proposal-class-properties": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
-          "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
-          "requires": {
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-member-expression-to-functions": "^7.0.0",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-replace-supers": "^7.1.0",
-            "@babel/plugin-syntax-class-properties": "^7.0.0"
-          }
-        },
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
-          "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
-          }
-        },
-        "@babel/plugin-syntax-class-properties": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
-          "integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-syntax-flow": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0.tgz",
-          "integrity": "sha512-zGcuZWiWWDa5qTZ6iAnpG0fnX/GOu49pGR5PFvkQ9GmKNaSphXQnlNXh/LG20sqWtNrx/eB6krzfEzcwvUyeFA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-syntax-jsx": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
-          "integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-syntax-object-rest-spread": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
-          "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-arrow-functions": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
-          "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-block-scoping": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
-          "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/plugin-transform-classes": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
-          "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.0.0",
-            "@babel/helper-define-map": "^7.1.0",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-replace-supers": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/plugin-transform-computed-properties": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
-          "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-destructuring": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz",
-          "integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-exponentiation-operator": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
-          "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
-          "requires": {
-            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-flow-strip-types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz",
-          "integrity": "sha512-WhXUNb4It5a19RsgKKbQPrjmy4yWOY1KynpEbNw7bnd1QTcrT/EIl3MJvnGgpgvrKyKbqX7nUNOJfkpLOnoDKA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-flow": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-for-of": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
-          "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
-          "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
-          "requires": {
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-literals": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
-          "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
-          "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.1.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-simple-access": "^7.1.0"
-          }
-        },
-        "@babel/plugin-transform-object-assign": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.0.0.tgz",
-          "integrity": "sha512-Dag8mxx7/03oj8F8PkNso8GEMhwGfeT0TL6KfMsa9Brjx4IpwZVl3WBvEmYks8BMhPmrvM5NQ/tjaMbwEj5ijA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-parameters": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
-          "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
-          "requires": {
-            "@babel/helper-call-delegate": "^7.1.0",
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-react-display-name": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
-          "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-react-jsx": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
-          "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
-          "requires": {
-            "@babel/helper-builder-react-jsx": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-jsx": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-react-jsx-source": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz",
-          "integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-jsx": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-regenerator": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
-          "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
-          "requires": {
-            "regenerator-transform": "^0.13.3"
-          }
-        },
-        "@babel/plugin-transform-shorthand-properties": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
-          "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-spread": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
-          "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-template-literals": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
-          "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-unicode-regex": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
-          "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-regex": "^7.0.0",
-            "regexpu-core": "^4.1.3"
-          }
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.0.0",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.1.0",
-            "@babel/types": "^7.0.0",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.5",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-              "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
         },
         "fbjs": {
-          "version": "0.8.17",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
           "requires": {
-            "core-js": "^1.0.0",
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
             "isomorphic-fetch": "^2.1.1",
             "loose-envify": "^1.0.0",
             "object-assign": "^4.1.0",
@@ -7948,20 +7203,55 @@
             "ua-parser-js": "^0.7.18"
           }
         },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+        "metro-babel7-plugin-react-transform": {
+          "version": "0.48.1",
+          "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.48.1.tgz",
+          "integrity": "sha512-b39Sowwzp0bqitbS3NkF5fzcuoT6vpLqj6Su7xgfCyW5EmYpvxunK7HwMSoZagAIpbD0H6r+iw+L2Ib1EEWfWw==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0"
+          }
         },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+        "metro-react-native-babel-preset": {
+          "version": "0.48.1",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.48.1.tgz",
+          "integrity": "sha512-euJ0MOyBYTa76kQNbly6An9FNpu9BqxfkXhKtD8hWZxo5dxIAk25AmoWfXU2OHj7PogG/u0Ndo3tmhZZ2NWYvA==",
+          "requires": {
+            "@babel/plugin-proposal-class-properties": "^7.0.0",
+            "@babel/plugin-proposal-export-default-from": "^7.0.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-export-default-from": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-object-assign": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-runtime": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typescript": "^7.0.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "@babel/template": "^7.0.0",
+            "metro-babel7-plugin-react-transform": "0.48.1",
+            "react-transform-hmr": "^1.0.4"
+          }
         },
         "mime-db": {
           "version": "1.23.0",
@@ -7976,43 +7266,17 @@
             "mime-db": "~1.23.0"
           }
         },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
         "node-fetch": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
           "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
-        },
-        "regenerator-transform": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
-          "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
-          "requires": {
-            "private": "^0.1.6"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         }
       }
     },
     "metro-babel-register": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.45.3.tgz",
-      "integrity": "sha512-B7KnOtkfBV5Cr98sArafPyQZLHC5dMcOX73fjg/x/ZYxhWgIe/Nz0OuRa7CahD1nn2sS7hcr1sMxYZD+I5N6wA==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.48.1.tgz",
+      "integrity": "sha512-bSjMAD16vpyHRWeMJ6CXvhWbFbiW58YXhA9zgRbFBdxOcJPbkhj6HEX+FlxTlr2O0MNY27/4U96MFXTcRWcZhQ==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
@@ -8028,241 +7292,77 @@
         "escape-string-regexp": "^1.0.5"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
-          "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
-          "requires": {
-            "@babel/types": "^7.0.0",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-          "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        }
+      }
+    },
+    "metro-babel7-plugin-react-transform": {
+      "version": "0.45.3",
+      "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.45.3.tgz",
+      "integrity": "sha512-lWsDtcPcmsJ/yB4fDS97S4NEcCnucTJKaJucVw9s90uzQc4xuqKAuoH6wfLo2y1voNjE+nRYRNNT9aeb5V9K1w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0"
+      },
+      "dependencies": {
         "@babel/helper-module-imports": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
           "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
-          "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/helper-simple-access": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/helper-optimise-call-expression": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-          "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
-          "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.0.0",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/traverse": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-          "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
-          "requires": {
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-          "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/plugin-proposal-class-properties": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
-          "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
-          "requires": {
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-member-expression-to-functions": "^7.0.0",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-replace-supers": "^7.1.0",
-            "@babel/plugin-syntax-class-properties": "^7.0.0"
-          }
-        },
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
-          "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
-          }
-        },
-        "@babel/plugin-proposal-optional-chaining": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.0.0.tgz",
-          "integrity": "sha512-7x8HLa71OzNiofbQUVakS0Kmg++6a+cXNfS7QKHbbv03SuSaumJyaWsfNgw+T7aqrJlqurYpZqrkPgXu0iZK0w==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-optional-chaining": "^7.0.0"
-          }
-        },
-        "@babel/plugin-syntax-class-properties": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
-          "integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-syntax-flow": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0.tgz",
-          "integrity": "sha512-zGcuZWiWWDa5qTZ6iAnpG0fnX/GOu49pGR5PFvkQ9GmKNaSphXQnlNXh/LG20sqWtNrx/eB6krzfEzcwvUyeFA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-syntax-object-rest-spread": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
-          "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-syntax-optional-chaining": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.0.0.tgz",
-          "integrity": "sha512-QXedQsZf8yua1nNrXSePT0TsGSQH9A1iK08m9dhCMdZeJaaxYcQfXdgHWVV6Cp7WE/afPVvSKIsAHK5wP+yxDA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-flow-strip-types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz",
-          "integrity": "sha512-WhXUNb4It5a19RsgKKbQPrjmy4yWOY1KynpEbNw7bnd1QTcrT/EIl3MJvnGgpgvrKyKbqX7nUNOJfkpLOnoDKA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-flow": "^7.0.0"
-          }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
-          "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.1.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-simple-access": "^7.1.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.0.0",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.1.0",
-            "@babel/types": "^7.0.0",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
           }
         },
         "@babel/types": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
           "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
+          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.10",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "metro-cache": {
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.48.1.tgz",
+      "integrity": "sha512-Nq1RQ7SkhVKKO/uWKzc6JtvDm0JJD/kDsoIQNR2Db37fNlyGxij0FoYRNOX3BOnyhz0NG8kU1pz0qH43bPQ5rg==",
+      "requires": {
+        "jest-serializer": "23.0.1",
+        "metro-core": "0.48.1",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4"
+      }
+    },
+    "metro-config": {
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.48.1.tgz",
+      "integrity": "sha512-pqdbDHUtoQPfWiL8h3x/cN5Q8w/sPt5/UaXk4oIzalU+ooEh0Hi9w10wJHKVRtWzD27o828O04En51C9eEDY5g==",
+      "requires": {
+        "cosmiconfig": "^5.0.5",
+        "metro": "0.48.1",
+        "metro-cache": "0.48.1",
+        "metro-core": "0.48.1",
+        "pretty-format": "^23.4.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -8272,134 +7372,37 @@
             "color-convert": "^1.9.0"
           }
         },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+        "pretty-format": {
+          "version": "23.6.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+          "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
           }
-        },
-        "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-        },
-        "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         }
-      }
-    },
-    "metro-babel7-plugin-react-transform": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.45.3.tgz",
-      "integrity": "sha512-lWsDtcPcmsJ/yB4fDS97S4NEcCnucTJKaJucVw9s90uzQc4xuqKAuoH6wfLo2y1voNjE+nRYRNNT9aeb5V9K1w==",
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-module-imports": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-          "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        }
-      }
-    },
-    "metro-cache": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.45.3.tgz",
-      "integrity": "sha512-LTOoz6iTbe383+GVa+inpDtfvbpoRZ86pG3HZhSvmjX9ZxcMqjtpLrC4UZ7Cwct0o2XYIkq5YIq7FfGtOtZWIw==",
-      "requires": {
-        "jest-serializer": "23.0.1",
-        "metro-core": "0.45.3",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4"
-      }
-    },
-    "metro-config": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.45.3.tgz",
-      "integrity": "sha512-6jgVoIZkM3gN8aUpu6ooYkOiLcqo8Suf8ItY7EYLCKN5rUF5yZdC8vaB6ZzcST3JeRs4q1vEneiorcMB8VlMVg==",
-      "requires": {
-        "cosmiconfig": "^5.0.5",
-        "metro": "0.45.3",
-        "metro-cache": "0.45.3",
-        "metro-core": "0.45.3"
       }
     },
     "metro-core": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.45.3.tgz",
-      "integrity": "sha512-YnbDmdUECUrLQKckeCxW3HvPJtcYjIqLsoh7Y4uC9M42QamG4FG+FqfX99TcZ3t9n+4GO7T5HJ2G/D9VzqXGBA==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.48.1.tgz",
+      "integrity": "sha512-uctosjP4imHThHlD5hAt0Yg7tiRLmY3GlU4VaIs0YH2i82yI56b93RtTCI1ACWhL7LUuttSVpPXCBN3ERTe+KA==",
       "requires": {
         "jest-haste-map": "23.5.0",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.45.3",
+        "metro-resolver": "0.48.1",
         "wordwrap": "^1.0.0"
       }
     },
     "metro-memory-fs": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-memory-fs/-/metro-memory-fs-0.45.3.tgz",
-      "integrity": "sha512-3FJUZqPGb0xxkEsQ6uWTufTkqrAzpVIyLq6z0GdiX103Onsdv2oKu9BqDnxIKcHTO93zNz7LwW0D/ZUAHRbE3w=="
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-memory-fs/-/metro-memory-fs-0.48.1.tgz",
+      "integrity": "sha512-ASbRBpmfRraFilm5o5gdY9X0DQAmkvCgAHDunCo0J2vlQ730VbuhhR67pVRmRr5oXXmDdEIYUkJSIqzP0Q+UKQ=="
     },
     "metro-minify-uglify": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.45.3.tgz",
-      "integrity": "sha512-BVWe1nuD99ADFTl4cs8OfHHRWKQ4d8mBWs+e+xnBED76uyLOsgqqNt1M/KseFkZdtCd/PBtzmpVcehl7WCeBxw==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.48.1.tgz",
+      "integrity": "sha512-8htDNs3dil5CopLnMrE6SGjMGg44KB+omE3ZyTNSWXbmZl8aG3spl+xpSJyvkIQrSFNSCzMVZ8V+lDJDwKJ/zg==",
       "requires": {
         "uglify-es": "^3.1.9"
       }
@@ -8408,6 +7411,7 @@
       "version": "0.45.3",
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.45.3.tgz",
       "integrity": "sha512-U36LVFqwkXBPCZbietnnmFiommECnMbuaVeQl6OGe1W4f4ol/ubQGOGr6kiY9LsQunpDVJZMHYQYph+lsip6tw==",
+      "dev": true,
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -8442,17 +7446,17 @@
       }
     },
     "metro-resolver": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.45.3.tgz",
-      "integrity": "sha512-buFxJ5gC9XXtoSWDhm54gxV9Eo9PmveCcxqfJ/XnW+Ss+Jkr7HeBu6IO0NEnwScxp1J8xWJIhtfoNsp4O2Toag==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.48.1.tgz",
+      "integrity": "sha512-d28ki5RTRUPFNQVJEgiMx3Zr81NlxOm1mKgaBx93Alyy2ZZ1Gvs25olZHwHgKPsRTgCqg5kgImkIHtjP2j8BdQ==",
       "requires": {
         "absolute-path": "^0.0.0"
       }
     },
     "metro-source-map": {
-      "version": "0.45.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.45.3.tgz",
-      "integrity": "sha512-XYKt1NsvOkkCJcLS2mLPZvH6O0fb6lGRYh5JYYzi0NTGc5ahogQLIPRv1wU1E3aDc9bKaPmMosFlAwhiNfIE7w==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.48.1.tgz",
+      "integrity": "sha512-6+YSKB3zRLGA39I0G/wfPizf1HPlrnmeX70E1vvH0G1HVD/ko5dqjJgH4vlr71Za9xYZLSuaXoQmmgkcf6at4w==",
       "requires": {
         "source-map": "^0.5.6"
       }
@@ -8536,7 +7540,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
@@ -8560,7 +7564,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -8862,7 +7866,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "requires": {
         "object-assign": "^4.0.1"
@@ -9047,7 +8051,7 @@
     },
     "pegjs": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
       "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
     },
     "performance-now": {
@@ -9142,7 +8146,7 @@
     },
     "pretty-format": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
       "integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
     },
     "private": {
@@ -9244,14 +8248,14 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "react": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.5.0.tgz",
-      "integrity": "sha512-nw/yB/L51kA9PsAy17T1JrzzGRk+BlFCJwFF7p+pwVxgqwPjYNeZEkkH7LXn9dmflolrYMXLWMTkQ77suKPTNQ==",
+      "version": "16.6.0-alpha.8af6728",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.6.0-alpha.8af6728.tgz",
+      "integrity": "sha512-W5NwSMey/JjF4wdeB7ek/+qG4bJJhgM1O/NaHvhUswgJxBMcFLUroODPELbq6IVolgua+anEirtOCx3fMXHZjw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "schedule": "^0.3.0"
+        "scheduler": "^0.10.0-alpha.8af6728"
       },
       "dependencies": {
         "prop-types": {
@@ -9276,9 +8280,9 @@
       "integrity": "sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA=="
     },
     "react-devtools-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.3.4.tgz",
-      "integrity": "sha512-6lsBDRInT9jU8Ya8bnKWJSsnaGg/xk1ZSfvhc/dHc3n2CUTMfGlqm2tGeZQ9WEoe0Y2K7Lg90Kvb1E8anLePaQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.4.0.tgz",
+      "integrity": "sha512-yV3LLhoRwbfcQyVPNwb1EZ9W7CGu+kX2EqyZ3Cl5C+cbXcb6FJ3YSeeBt9BQB+hjyjRMBjQSKqnpPS6OMSEUow==",
       "requires": {
         "shell-quote": "^1.6.1",
         "ws": "^3.3.1"
@@ -9302,9 +8306,9 @@
       }
     },
     "react-is": {
-      "version": "16.5.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.1.tgz",
-      "integrity": "sha512-Q7S+9y2lJA9oJCMqLt045f+kLRhsMLA1wW2DAGXA6b7wcTQRHnUDMc5oR49tn0Z4swvnfV+/t8iZFXY74IQmpA==",
+      "version": "16.6.0-alpha.8af6728",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0-alpha.8af6728.tgz",
+      "integrity": "sha512-F65AeMavskvRglteO7dC0Nvq3Br1ESnpCOG5M6fenQX52Uhpt6eCI0vL3ICM/hnVhIOQY2fwnSWtST33OlgxVA==",
       "dev": true
     },
     "react-lifecycles-compat": {
@@ -9313,10 +8317,11 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-native": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.57.0.tgz",
-      "integrity": "sha512-L/bPmqWsei1EyHdikg/jOdl9unVyrehmkoNlkGCl3Y5Zr7KGE36j+DOL6M0OqpGVkWIXJ5Jzk/ttea/X3edVVg==",
+      "version": "0.57.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.57.3.tgz",
+      "integrity": "sha512-FmJQdGjo0rEfEYbw+dhMPn2P/vDpvPebAwL3YDaQ/iYSi+IGPNHdepEaDpU1vfFOAnxrh3BlfACC+RsoeQ3SWw==",
       "requires": {
+        "@babel/runtime": "^7.0.0",
         "absolute-path": "^0.0.0",
         "art": "^0.10.0",
         "base64-js": "^1.1.2",
@@ -9331,17 +8336,17 @@
         "errorhandler": "^1.5.0",
         "escape-string-regexp": "^1.0.5",
         "event-target-shim": "^1.0.5",
-        "fbjs": "0.8.17",
+        "fbjs": "^1.0.0",
         "fbjs-scripts": "^0.8.1",
         "fs-extra": "^1.0.0",
         "glob": "^7.1.1",
         "graceful-fs": "^4.1.3",
         "inquirer": "^3.0.6",
         "lodash": "^4.17.5",
-        "metro": "^0.45.0",
-        "metro-babel-register": "^0.45.0",
-        "metro-core": "^0.45.0",
-        "metro-memory-fs": "^0.45.0",
+        "metro": "^0.48.1",
+        "metro-babel-register": "^0.48.1",
+        "metro-core": "^0.48.1",
+        "metro-memory-fs": "^0.48.1",
         "mime": "^1.3.4",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
@@ -9356,7 +8361,7 @@
         "promise": "^7.1.1",
         "prop-types": "^15.5.8",
         "react-clone-referenced-element": "^1.0.1",
-        "react-devtools-core": "3.3.4",
+        "react-devtools-core": "^3.4.0",
         "react-timer-mixin": "^0.13.2",
         "regenerator-runtime": "^0.11.0",
         "rimraf": "^2.5.4",
@@ -9396,9 +8401,14 @@
             "restore-cursor": "^2.0.0"
           }
         },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "requires": {
             "chardet": "^0.4.0",
@@ -9407,11 +8417,12 @@
           }
         },
         "fbjs": {
-          "version": "0.8.17",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
           "requires": {
-            "core-js": "^1.0.0",
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
             "isomorphic-fetch": "^2.1.1",
             "loose-envify": "^1.0.0",
             "object-assign": "^4.1.0",
@@ -9481,7 +8492,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mute-stream": {
@@ -9712,15 +8723,27 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.3.1.tgz",
-      "integrity": "sha512-emEcIPUowMjT5EQ+rrb0FAwVCzuJ+LKDweoYDh073v2/jHxrBDPUk8nzI5dofG3R+140+Bb9TMcT2Ez5OP6pQw==",
+      "version": "16.6.0-alpha.8af6728",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.6.0-alpha.8af6728.tgz",
+      "integrity": "sha512-42RB1hvEjVuJGrGddGqVj1obs9NhWiuijkz+qsuY0qRzF0ygD5xg4eRdm0H4YNtkp+332g6OWO9O2ussu67cFQ==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0",
-        "react-is": "^16.3.1"
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0-alpha.8af6728",
+        "scheduler": "^0.10.0-alpha.8af6728"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-timer-mixin": {
@@ -9758,7 +8781,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -10386,21 +9409,22 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "sax": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
     },
-    "schedule": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.3.0.tgz",
-      "integrity": "sha512-20+1KVo517sR7Nt+bYBN8a+bEJDKLPEx7Ohtts1kX05E4/HY53YUNuhfkVNItmWAnBYHcpG9vsd2/CJxG+aPCQ==",
+    "scheduler": {
+      "version": "0.10.0-alpha.f47a958",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.10.0-alpha.f47a958.tgz",
+      "integrity": "sha512-GVz1gvEU4JhqqiLB+DhRwd17sqKCmVsmdrsDoKMOIRCu0z+qYhimF6PvA3q61BgCqHDWJZiAidom6saiE8ZrOQ==",
       "requires": {
+        "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
     },
@@ -10443,7 +9467,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serve-static": {
@@ -11027,7 +10051,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }
@@ -11139,7 +10163,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -11542,7 +10566,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -11615,7 +10639,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -13,8 +13,8 @@
     "appcenter-crashes": "file:appcenter-crashes-1.8.1.tgz",
     "appcenter-link-scripts": "file:appcenter-link-scripts-1.8.1.tgz",
     "appcenter-push": "file:appcenter-push-1.8.1.tgz",
-    "react": "16.5.0",
-    "react-native": "^0.57.0",
+    "react": "16.6.0-alpha.8af6728",
+    "react-native": "0.57.3",
     "react-native-dialog-input": "^1.0.4",
     "react-native-fs": "^2.9.12",
     "react-native-image-picker": "^0.26.7",
@@ -36,7 +36,7 @@
     "jest": "22.4.3",
     "metro-react-native-babel-preset": "^0.45.3",
     "prop-types": "15.6.0",
-    "react-test-renderer": "16.3.1"
+    "react-test-renderer": "16.6.0-alpha.8af6728"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
RN CI is failing on `jest` (https://msmobilecenter.visualstudio.com/SDK/_build/results?buildId=352503&view=logs) due to [an issue with RN v0.57.0 and fixed in RN v0.57.3](https://github.com/facebook/react-native/issues/21150#issuecomment-429305215). 

Per the above GitHub thread, we just need to ping `react-native` to v0.57.3 and upgrade the `react-test-renderer` dependency to the proper version.