### PR TITLE
Fix gradle sync error in android studio for demo app

### DIFF
--- a/DemoApp/android/build.gradle
+++ b/DemoApp/android/build.gradle
@@ -14,8 +14,8 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
         google()
+        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"


### PR DESCRIPTION
The error is probably related to Android Studio 3.2 but we have documented that order in push for a long time already.