### PR TITLE
Send error attachment if filename is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fix lint issue on modern projects using latest react-native versions [#451](https://github.com/Microsoft/AppCenter-SDK-React-Native/issues/451).
 - Use latest Firebase version [#365](https://github.com/Microsoft/AppCenter-SDK-React-Native/issues/365).
-- [Android] Fix bug preventing ErrorAttachmentLog from being send if fileName is not specified.
+- [Android] Fix a bug which prevents ErrorAttachmentLog from being send if fileName is not specified.
 
 ## Version 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Fixes
 
-* Fix lint issue on modern projects using latest react-native versions [#451](https://github.com/Microsoft/AppCenter-SDK-React-Native/issues/451).
-* Use latest Firebase version [#365](https://github.com/Microsoft/AppCenter-SDK-React-Native/issues/365).
+- Fix lint issue on modern projects using latest react-native versions [#451](https://github.com/Microsoft/AppCenter-SDK-React-Native/issues/451).
+- Use latest Firebase version [#365](https://github.com/Microsoft/AppCenter-SDK-React-Native/issues/365).
+- [Android] Fix bug preventing ErrorAttachmentLog from being send if fileName is not specified.
 
 ## Version 1.9.0
 

--- a/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesModule.java
+++ b/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesModule.java
@@ -183,7 +183,10 @@ public class AppCenterReactNativeCrashesModule extends BaseJavaModule {
             Collection<ErrorAttachmentLog> attachmentLogs = new LinkedList<>();
             for (int i = 0; i < attachments.size(); i++) {
                 ReadableMap jsAttachment = attachments.getMap(i);
-                String fileName = jsAttachment.getString("fileName");
+                String fileName = null;
+                if (jsAttachment.hasKey("fileName")) {
+                    fileName = jsAttachment.getString("fileName");
+                }
                 if (jsAttachment.hasKey("text")) {
                     String text = jsAttachment.getString("text");
                     attachmentLogs.add(ErrorAttachmentLog.attachmentWithText(text, fileName));

--- a/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesModule.java
+++ b/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesModule.java
@@ -27,6 +27,11 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class AppCenterReactNativeCrashesModule extends BaseJavaModule {
 
+    private static final String DATA_FIELD = "data";
+    private static final String TEXT_FIELD = "text";
+    private static final String FILE_NAME_FIELD = "fileName";
+    private static final String CONTENT_TYPE_FIELD = "contentType";
+
     /**
      * Constant for DO NOT SEND crash report.
      */
@@ -184,16 +189,16 @@ public class AppCenterReactNativeCrashesModule extends BaseJavaModule {
             for (int i = 0; i < attachments.size(); i++) {
                 ReadableMap jsAttachment = attachments.getMap(i);
                 String fileName = null;
-                if (jsAttachment.hasKey("fileName")) {
-                    fileName = jsAttachment.getString("fileName");
+                if (jsAttachment.hasKey(FILE_NAME_FIELD)) {
+                    fileName = jsAttachment.getString(FILE_NAME_FIELD);
                 }
-                if (jsAttachment.hasKey("text")) {
-                    String text = jsAttachment.getString("text");
+                if (jsAttachment.hasKey(TEXT_FIELD)) {
+                    String text = jsAttachment.getString(TEXT_FIELD);
                     attachmentLogs.add(ErrorAttachmentLog.attachmentWithText(text, fileName));
                 } else {
-                    String encodedData = jsAttachment.getString("data");
+                    String encodedData = jsAttachment.getString(DATA_FIELD);
                     byte[] data = Base64.decode(encodedData, Base64.DEFAULT);
-                    String contentType = jsAttachment.getString("contentType");
+                    String contentType = jsAttachment.getString(CONTENT_TYPE_FIELD);
                     attachmentLogs.add(ErrorAttachmentLog.attachmentWithBinary(data, fileName, contentType));
                 }
             }


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

When `fileName` parameter is ommited when calling `attachmentWithText` the error attachment log will not be send. This pr fixes it/

## Related PRs or issues
https://github.com/Microsoft/AppCenter-SDK-Android/issues/754/

