### PR TITLE
Fix metro dependency

### DIFF
--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -13,6 +13,7 @@
     "appcenter-crashes": "file:appcenter-crashes-1.10.0.tgz",
     "appcenter-link-scripts": "file:appcenter-link-scripts-1.10.0.tgz",
     "appcenter-push": "file:appcenter-push-1.10.0.tgz",
+    "metro": "0.48.1",
     "react": "16.6.0-alpha.8af6728",
     "react-native": "0.57.3",
     "react-native-fs": "^2.9.12",


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Because react-native depends on "^0.48.1" inexact version, version 0.48.3 is pulled which uses alpha versions of some jest dependencies and thus break Javascript server:

```
> node node_modules/react-native/local-cli/cli.js start

┌──────────────────────────────────────────────────────────────────────────────┐
│                                                                              │
│  Running Metro Bundler on port 8081.                                         │
│                                                                              │
│  Keep Metro running while developing on any JS projects. Feel free to        │
│  close this tab and run your own Metro instance if you prefer.               │
│                                                                              │
│  https://github.com/facebook/react-native                                    │
│                                                                              │
└──────────────────────────────────────────────────────────────────────────────┘

Looking for JS files in
   /Users/guperrot/git/testapp 

Loading dependency graph...(node:43290) UnhandledPromiseRejectionWarning: Error: Cannot find module 'jest-serializer'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at _load_jestSerializer (/Users/guperrot/git/testapp/node_modules/jest-haste-map/build/index.js:164:52)
    at HasteMap._persist (/Users/guperrot/git/testapp/node_modules/jest-haste-map/build/index.js:781:25)
    at _buildPromise._buildFileMap.then.then.hasteMap (/Users/guperrot/git/testapp/node_modules/jest-haste-map/build/index.js:425:16)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
(node:43290) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:43290) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:43290) UnhandledPromiseRejectionWarning: Error: Cannot find module 'jest-serializer'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at _load_jestSerializer (/Users/guperrot/git/testapp/node_modules/jest-haste-map/build/index.js:164:52)
    at HasteMap._persist (/Users/guperrot/git/testapp/node_modules/jest-haste-map/build/index.js:781:25)
    at _buildPromise._buildFileMap.then.then.hasteMap (/Users/guperrot/git/testapp/node_modules/jest-haste-map/build/index.js:425:16)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
(node:43290) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
```

This can also be reproduced in a brand new react-native application without our SDK, react-native has not fixed it, metro 0.50.0 still has the issue while it's the latest version. The only stable version seems to be be 0.48.1.