### PR TITLE
Fix initial state of transmission target in demo apps

### DIFF
--- a/DemoApp/app/screens/TransmissionScreen.js
+++ b/DemoApp/app/screens/TransmissionScreen.js
@@ -48,6 +48,12 @@ export default class TransmissionScreen extends Component {
   async componentWillMount() {
     await AppCenter.startFromLibrary(Analytics);
     await this.createTargetsFromTokens(0, Analytics);
+
+    const transmissionTarget = this.transmissionTargets[this.state.targetToken.key];
+    if (transmissionTarget) {
+      const targetEnabled = await transmissionTarget.isEnabled();
+      this.setState({ targetEnabled });
+    }
   }
 
   async createTargetsFromTokens(index, parentTarget) {

--- a/TestApp/app/screens/TransmissionScreen.js
+++ b/TestApp/app/screens/TransmissionScreen.js
@@ -48,6 +48,12 @@ export default class TransmissionScreen extends Component {
   async componentWillMount() {
     await AppCenter.startFromLibrary(Analytics);
     await this.createTargetsFromTokens(0, Analytics);
+
+    const transmissionTarget = this.transmissionTargets[this.state.targetToken.key];
+    if (transmissionTarget) {
+      const targetEnabled = await transmissionTarget.isEnabled();
+      this.setState({ targetEnabled });
+    }
   }
 
   async createTargetsFromTokens(index, parentTarget) {


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

### Repro Steps

- Install SDK test React Native Android 1.0(215) app
- Launch the app and click Transmission tab
- Disabled Transmission Target "Parent Target Token" 
- Kill the app and restart it 
- Re-click Transmission tab to observe the "Parent Target Token" status
- Switch to Child or Grandchild Target to observe the status
- Switch back to the Parent Target to observe the status

### Expected Behaviour
Parent Transmission Target should be disabled when changed it to disabled and restart it.

### Actual Behaviour
Parent Transmission Target displayed enabled status after switching to disabled and restart the app.