### PR TITLE
Release/fix read conf file

### DIFF
--- a/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
+++ b/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
@@ -58,24 +58,24 @@ public class AppCenterReactNativeShared {
     }
 
     private static void readConfigurationFile() {
-        if (sAppSecret == null) {
-            try {
-                AppCenterLog.debug(LOG_TAG, "Reading " + APPCENTER_CONFIG_ASSET);
-                InputStream configStream = sApplication.getAssets().open(APPCENTER_CONFIG_ASSET);
-                int size = configStream.available();
-                byte[] buffer = new byte[size];
+        try {
+            AppCenterLog.debug(LOG_TAG, "Reading " + APPCENTER_CONFIG_ASSET);
+            InputStream configStream = sApplication.getAssets().open(APPCENTER_CONFIG_ASSET);
+            int size = configStream.available();
+            byte[] buffer = new byte[size];
 
-                //noinspection ResultOfMethodCallIgnored
-                configStream.read(buffer);
-                configStream.close();
-                String jsonContents = new String(buffer, "UTF-8");
-                sConfiguration = new JSONObject(jsonContents);
+            //noinspection ResultOfMethodCallIgnored
+            configStream.read(buffer);
+            configStream.close();
+            String jsonContents = new String(buffer, "UTF-8");
+            sConfiguration = new JSONObject(jsonContents);
+            if (sAppSecret == null) {
                 sAppSecret = sConfiguration.optString(APP_SECRET_KEY);
                 sStartAutomatically = sConfiguration.optBoolean(START_AUTOMATICALLY_KEY, true);
-            } catch (Exception e) {
-                AppCenterLog.error(LOG_TAG, "Failed to parse appcenter-config.json", e);
-                sConfiguration = new JSONObject();
             }
+        } catch (Exception e) {
+            AppCenterLog.error(LOG_TAG, "Failed to parse appcenter-config.json", e);
+            sConfiguration = new JSONObject();
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Introduce new `LogLevel` constants, deprecating old ones.
 - Fix bug with linking process being stuck when developing on windows machines. [#471](https://github.com/Microsoft/AppCenter-SDK-React-Native/issues/471).
+- Fixes crash on startup if `setAppSecret` method of `AppCenterReactNativeShared` was called.
 
 ### AppCenterCrashes
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

If `setAppSecret` method of `AppCenterReactNativeShared` was called SDK won't read configuration file thus crashing on startup as modules depend on the presence of the configuration object.

