### PR TITLE
Fix/testapp android build warnings

### DIFF
--- a/TestApp/android/build.gradle
+++ b/TestApp/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.2"
+        buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 27

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -17,7 +17,7 @@
     "react": "16.6.3",
     "react-native": "0.58.3",
     "react-native-fs": "^2.9.12",
-    "react-native-image-picker": "^0.26.7",
+    "react-native-image-picker": "^0.28.0",
     "react-native-modal-selector": "^1.0.2",
     "react-native-simple-toast": "0.0.8",
     "react-navigation": "^2.11.2"


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes Android build warnings:

- Updates `react-native-image-picker` to the latest version to fix `WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.`
- Changes `buildToolsVersion` to `28.0.3` to fix `WARNING: The specified Android SDK Build Tools version (28.0.2) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.2.1.`

## Misc

Full message of the second warning:

>WARNING: The specified Android SDK Build Tools version (27.0.3) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.2.1.
>Android SDK Build Tools 28.0.3 will be used.
>To suppress this warning, remove "buildToolsVersion '27.0.3'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.

This warning is caused by using incorrect versions of `buildToolsVersion` (it was changed [based on rn-diff-purge](https://github.com/pvinis/rn-diff-purge/compare/version/0.57.3...version/0.58.3#diff-417a723a0514857b498bf4ac820e272bR5)).

As the message says we can remove `buildToolsVersion` from SDK configs (e.g. it [was removed from React Native](https://github.com/facebook/react-native/commit/f3e5cce4745c0ad9a5c697be772757a03e15edc5#diff-5e734c5ae45d1357db7325ab409bb503L95)).