### PR TITLE
Bump xcode to ^2.0.0

### DIFF
--- a/appcenter-link-scripts/package.json
+++ b/appcenter-link-scripts/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^0.5.1",
     "plist": "^3.0.1",
     "which": "^1.2.11",
-    "xcode": "^1.0.0"
+    "xcode": "^2.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

`appcenter-link-scripts` has vulnerability dependency of Regular Expression Denial of Service (ReDoS)
 through `xcode` 1.1.0 https://app.snyk.io/test/npm/appcenter/1.12.2

Introduced through: appcenter@1.12.2 › appcenter-link-scripts@1.12.2 › xcode@1.1.0 › simple-plist@0.2.1 › plist@2.0.1

Reference: https://app.snyk.io/vuln/npm:plist:20180219

## Related PRs or issues

None.

## Misc

`xcode` 2.0.0 doesn't introduce breaking changes from 1.1.0. https://github.com/apache/cordova-node-xcode/blob/master/RELEASENOTES.md
