### PR TITLE
Add null check for ErrorReport throwable

### DIFF
--- a/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesUtils.java
+++ b/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesUtils.java
@@ -41,10 +41,13 @@ class AppCenterReactNativeCrashesUtils {
         errorReportMap.putString("threadName", errorReport.getThreadName());
         errorReportMap.putString("appErrorTime", "" + errorReport.getAppErrorTime().getTime());
         errorReportMap.putString("appStartTime", "" + errorReport.getAppStartTime().getTime());
-        errorReportMap.putString("exception", Log.getStackTraceString(errorReport.getThrowable()));
+        
         //noinspection ThrowableResultOfMethodCallIgnored
-        errorReportMap.putString("exceptionReason", errorReport.getThrowable().getMessage());
-
+        Throwable error = errorReport.getThrowable();
+        if (error != null) {
+            errorReportMap.putString("exception", Log.getStackTraceString(error));
+            errorReportMap.putString("exceptionReason", error.getMessage());
+        }
         /* Convert device info. */
         Device deviceInfo = errorReport.getDevice();
         WritableMap deviceInfoMap;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
I had an app that was occasionally getting into a state where a pending crash report was causing the app to crash again on launch with a NullPointerException on `getThrowable().getMessage()`. This PR adds a null check for the error report throwable. 