### PR TITLE
Fix saving userId in test/demo apps

### DIFF
--- a/DemoApp/app/screens/AppCenterScreen.js
+++ b/DemoApp/app/screens/AppCenterScreen.js
@@ -12,6 +12,8 @@ import Push from 'appcenter-push';
 import SharedStyles from '../SharedStyles';
 import DialsTabBarIcon from '../assets/dials.png';
 
+const USER_ID_KEY = 'USER_ID_KEY';
+
 const SecretStrings = {
   ios: {
     appSecret: 'f5f84a76-6622-437a-9130-07b27d3c72e7',
@@ -75,7 +77,6 @@ export default class AppCenterScreen extends Component {
 
   async componentWillMount() {
     await this.refreshUI();
-
     const startupModeKey = await AsyncStorage.getItem(STARTUP_MODE);
     for (let index = 0; index < StartupModes.length; index++) {
       const startupMode = StartupModes[index];
@@ -84,7 +85,11 @@ export default class AppCenterScreen extends Component {
         break;
       }
     }
-
+    const userId = await AsyncStorage.getItem(USER_ID_KEY);
+    if (userId !== null) {
+      this.state.userId = userId;
+      await AppCenter.setUserId(userId);
+    }
     this.props.navigation.setParams({
       refreshAppCenterScreen: this.refreshUI.bind(this)
     });
@@ -155,7 +160,7 @@ export default class AppCenterScreen extends Component {
     const valueRenderItem = ({ item: { title, value, onChange, onSubmit } }) => (
       <View style={SharedStyles.item}>
         <Text style={SharedStyles.itemTitle}>{title}</Text>
-        { onChange ? <TextInput style={SharedStyles.itemInput} onSubmitEditing={onSubmit} onChangeText={onChange}>{this.state[value]}</TextInput> : <Text>{this.state[value]}</Text> }
+        {onChange ? <TextInput style={SharedStyles.itemInput} onSubmitEditing={onSubmit} onChangeText={onChange}>{this.state[value]}</TextInput> : <Text>{this.state[value]}</Text>}
       </View>
     );
 
@@ -238,8 +243,13 @@ export default class AppCenterScreen extends Component {
                     this.setState({ userId });
                   },
                   onSubmit: async () => {
-                    // 1DS setUserId API allows null but not empty string as userId
+                    // We use empty text in UI to delete userID (null for AppCenter API).
                     const userId = this.state.userId.length === 0 ? null : this.state.userId;
+                    if (userId !== null) {
+                      await AsyncStorage.setItem(USER_ID_KEY, userId);
+                    } else {
+                      await AsyncStorage.removeItem(USER_ID_KEY);
+                    }
                     await AppCenter.setUserId(userId);
                   }
                 }

--- a/DemoApp/app/screens/AppCenterScreen.js
+++ b/DemoApp/app/screens/AppCenterScreen.js
@@ -150,10 +150,12 @@ export default class AppCenterScreen extends Component {
       </View>
     );
 
-    const valueRenderItem = ({ item: { title, value, onChange } }) => (
+    // After trying to fix the next line lint warning, the code was harder to read and format, disable it once.
+    // eslint-disable-next-line object-curly-newline
+    const valueRenderItem = ({ item: { title, value, onChange, onSubmit } }) => (
       <View style={SharedStyles.item}>
         <Text style={SharedStyles.itemTitle}>{title}</Text>
-        { onChange ? <TextInput style={SharedStyles.itemInput} onChangeText={onChange}>{this.state[value]}</TextInput> : <Text>{this.state[value]}</Text> }
+        { onChange ? <TextInput style={SharedStyles.itemInput} onSubmitEditing={onSubmit} onChangeText={onChange}>{this.state[value]}</TextInput> : <Text>{this.state[value]}</Text> }
       </View>
     );
 
@@ -234,6 +236,10 @@ export default class AppCenterScreen extends Component {
                   value: 'userId',
                   onChange: async (userId) => {
                     this.setState({ userId });
+                  },
+                  onSubmit: async () => {
+                    // 1DS setUserId API allows null but not empty string as userId
+                    const userId = this.state.userId.length === 0 ? null : this.state.userId;
                     await AppCenter.setUserId(userId);
                   }
                 }

--- a/DemoApp/app/screens/CrashesScreen.js
+++ b/DemoApp/app/screens/CrashesScreen.js
@@ -29,7 +29,8 @@ export default class CrashesScreen extends Component {
     crashesEnabled: false,
     lastSessionStatus: '',
     textAttachment: '',
-    binaryAttachment: ''
+    binaryAttachment: '',
+    userId: ''
   }
 
   async componentWillMount() {

--- a/TestApp/app/screens/AppCenterScreen.js
+++ b/TestApp/app/screens/AppCenterScreen.js
@@ -85,7 +85,11 @@ export default class AppCenterScreen extends Component {
         break;
       }
     }
-    this.state.userId = await AsyncStorage.getItem(USER_ID_KEY);
+    const userId = await AsyncStorage.getItem(USER_ID_KEY);
+    if (userId !== null) {
+      this.state.userId = userId;
+      await AppCenter.setUserId(userId);
+    }
     this.props.navigation.setParams({
       refreshAppCenterScreen: this.refreshUI.bind(this)
     });
@@ -156,7 +160,7 @@ export default class AppCenterScreen extends Component {
     const valueRenderItem = ({ item: { title, value, onChange, onSubmit } }) => (
       <View style={SharedStyles.item}>
         <Text style={SharedStyles.itemTitle}>{title}</Text>
-        { onChange ? <TextInput style={SharedStyles.itemInput} onSubmitEditing={onSubmit} onChangeText={onChange}>{this.state[value]}</TextInput> : <Text>{this.state[value]}</Text> }
+        {onChange ? <TextInput style={SharedStyles.itemInput} onSubmitEditing={onSubmit} onChangeText={onChange}>{this.state[value]}</TextInput> : <Text>{this.state[value]}</Text>}
       </View>
     );
 
@@ -239,12 +243,14 @@ export default class AppCenterScreen extends Component {
                     this.setState({ userId });
                   },
                   onSubmit: async () => {
-                    await AsyncStorage.setItem(USER_ID_KEY, this.state.userId);
 
-                    // Note that app UI doesn't differentiate empty string from null string,
-                    // but setUserId API allows null but not empty string,
-                    // so convert empty userId to null.
+                    // We use empty text in UI to delete userID (null for AppCenter API).
                     const userId = this.state.userId.length === 0 ? null : this.state.userId;
+                    if (userId !== null) {
+                      await AsyncStorage.setItem(USER_ID_KEY, userId);
+                    } else {
+                      await AsyncStorage.removeItem(USER_ID_KEY);
+                    }
                     await AppCenter.setUserId(userId);
                   }
                 }

--- a/TestApp/app/screens/AppCenterScreen.js
+++ b/TestApp/app/screens/AppCenterScreen.js
@@ -12,6 +12,8 @@ import Push from 'appcenter-push';
 import SharedStyles from '../SharedStyles';
 import DialsTabBarIcon from '../assets/dials.png';
 
+const USER_ID_KEY = 'USER_ID_KEY';
+
 const SecretStrings = {
   ios: {
     appSecret: 'e59c0968-b7e3-474d-85ad-6dcfaffb8bf5',
@@ -83,7 +85,7 @@ export default class AppCenterScreen extends Component {
         break;
       }
     }
-
+    this.state.userId = await AsyncStorage.getItem(USER_ID_KEY);
     this.props.navigation.setParams({
       refreshAppCenterScreen: this.refreshUI.bind(this)
     });
@@ -237,7 +239,11 @@ export default class AppCenterScreen extends Component {
                     this.setState({ userId });
                   },
                   onSubmit: async () => {
-                    // 1DS setUserId API allows null but not empty string as userId
+                    await AsyncStorage.setItem(USER_ID_KEY, this.state.userId);
+
+                    // Note that app UI doesn't differentiate empty string from null string,
+                    // but setUserId API allows null but not empty string,
+                    // so convert empty userId to null.
                     const userId = this.state.userId.length === 0 ? null : this.state.userId;
                     await AppCenter.setUserId(userId);
                   }

--- a/TestApp/app/screens/AppCenterScreen.js
+++ b/TestApp/app/screens/AppCenterScreen.js
@@ -243,7 +243,6 @@ export default class AppCenterScreen extends Component {
                     this.setState({ userId });
                   },
                   onSubmit: async () => {
-
                     // We use empty text in UI to delete userID (null for AppCenter API).
                     const userId = this.state.userId.length === 0 ? null : this.state.userId;
                     if (userId !== null) {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

UserId is now saved in UI of test and demo apps.
[AB#61530](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/61530)