### PR TITLE
Modified read to return DocumentWrapper properties

### DIFF
--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const ReactNative = require('react-native');
+const ReactNative = require("react-native");
 
 const { AppCenterReactNativeData } = ReactNative.NativeModules;
 
 const Data = {
     read(documentId, partition) {
-        return AppCenterReactNativeData.read(documentId, partition);
+        return AppCenterReactNativeData.read(documentId, partition).then(result => {
+            result.lastUpdatedDate = new Date(result.lastUpdatedDate);
+            return result;
+        });
     }
 };
 

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -8,6 +8,8 @@ const { AppCenterReactNativeData } = ReactNative.NativeModules;
 const Data = {
     read(documentId, partition) {
         return AppCenterReactNativeData.read(documentId, partition).then(result => {
+
+            // Create a new `Date` object from timestamp as milliseconds
             result.lastUpdatedDate = new Date(result.lastUpdatedDate);
             return result;
         });

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const ReactNative = require("react-native");
+const ReactNative = require('react-native');
 
 const { AppCenterReactNativeData } = ReactNative.NativeModules;
 

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
@@ -64,6 +64,8 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
                 WritableMap jsDocumentWrapper = new WritableNativeMap();
                 jsDocumentWrapper.putString(JSON_VALUE_FIELD, documentWrapper.getJsonValue());
                 jsDocumentWrapper.putString(ETAG_FIELD, documentWrapper.getETag());
+
+                // Pass milliseconds back to JS object since `WritableMap` does not support `Date` as values
                 jsDocumentWrapper.putDouble(LAST_UPDATED_DATE_FIELD, documentWrapper.getLastUpdatedDate().getTime());
                 jsDocumentWrapper.putBoolean(IS_FROM_DEVICE_CACHE_FIELD, documentWrapper.isFromDeviceCache());
                 jsDocumentWrapper.putString(ID_FIELD, documentWrapper.getId());

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
@@ -49,7 +49,7 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
     }
 
     @ReactMethod
-    public void read(String documentId, final String partition, final Promise promise) {
+    public void read(String documentId, String partition, final Promise promise) {
         Data.read(documentId, JsonElement.class, partition).thenAccept(new AppCenterConsumer<DocumentWrapper<JsonElement>>() {
 
             @Override

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
@@ -29,11 +29,17 @@ import com.microsoft.appcenter.utils.async.AppCenterConsumer;
 public class AppCenterReactNativeDataModule extends BaseJavaModule {
 
     private static final String DESERIALIZED_VALUE_FIELD = "deserializedValue";
+
     private static final String JSON_VALUE_FIELD = "jsonValue";
-    private static final String ETAG_FIELD = "etag";
+
+    private static final String ETAG_FIELD = "eTag";
+
     private static final String LAST_UPDATED_DATE_FIELD = "lastUpdatedDate";
+
     private static final String IS_FROM_DEVICE_CACHE_FIELD = "isFromDeviceCache";
+
     private static final String ID_FIELD = "id";
+
     private static final String PARTITION_FIELD = "partition";
 
     public AppCenterReactNativeDataModule(Application application) {
@@ -62,9 +68,7 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
                 jsDocumentWrapper.putBoolean(IS_FROM_DEVICE_CACHE_FIELD, documentWrapper.isFromDeviceCache());
                 jsDocumentWrapper.putString(ID_FIELD, documentWrapper.getId());
                 jsDocumentWrapper.putString(PARTITION_FIELD, documentWrapper.getPartition());
-                if (deserializedValue == null || deserializedValue.isJsonNull()) {
-                    jsDocumentWrapper.putNull(DESERIALIZED_VALUE_FIELD);
-                } else if (deserializedValue.isJsonPrimitive()) {
+                if (deserializedValue.isJsonPrimitive()) {
                     JsonPrimitive jsonPrimitive = deserializedValue.getAsJsonPrimitive();
                     if (jsonPrimitive.isString()) {
                         jsDocumentWrapper.putString(DESERIALIZED_VALUE_FIELD, jsonPrimitive.getAsString());
@@ -81,6 +85,8 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
                     JsonArray jsonArray = deserializedValue.getAsJsonArray();
                     WritableArray writableArray = convertJsonArrayToWritableArray(jsonArray);
                     jsDocumentWrapper.putArray(DESERIALIZED_VALUE_FIELD, writableArray);
+                } else {
+                    jsDocumentWrapper.putNull(DESERIALIZED_VALUE_FIELD);
                 }
                 promise.resolve(jsDocumentWrapper);
             }

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
@@ -28,19 +28,19 @@ import com.microsoft.appcenter.utils.async.AppCenterConsumer;
 
 public class AppCenterReactNativeDataModule extends BaseJavaModule {
 
-    private static final String DESERIALIZED_VALUE_FIELD = "deserializedValue";
+    private static final String DESERIALIZED_VALUE_KEY = "deserializedValue";
 
-    private static final String JSON_VALUE_FIELD = "jsonValue";
+    private static final String JSON_VALUE_KEY = "jsonValue";
 
-    private static final String ETAG_FIELD = "eTag";
+    private static final String ETAG_KEY = "eTag";
 
-    private static final String LAST_UPDATED_DATE_FIELD = "lastUpdatedDate";
+    private static final String LAST_UPDATED_DATE_KEY = "lastUpdatedDate";
 
-    private static final String IS_FROM_DEVICE_CACHE_FIELD = "isFromDeviceCache";
+    private static final String IS_FROM_DEVICE_CACHE_KEY = "isFromDeviceCache";
 
-    private static final String ID_FIELD = "id";
+    private static final String ID_KEY = "id";
 
-    private static final String PARTITION_FIELD = "partition";
+    private static final String PARTITION_KEY = "partition";
 
     public AppCenterReactNativeDataModule(Application application) {
         AppCenterReactNativeShared.configureAppCenter(application);
@@ -62,33 +62,33 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
             public void accept(DocumentWrapper<JsonElement> documentWrapper) {
                 JsonElement deserializedValue = documentWrapper.getDeserializedValue();
                 WritableMap jsDocumentWrapper = new WritableNativeMap();
-                jsDocumentWrapper.putString(JSON_VALUE_FIELD, documentWrapper.getJsonValue());
-                jsDocumentWrapper.putString(ETAG_FIELD, documentWrapper.getETag());
+                jsDocumentWrapper.putString(JSON_VALUE_KEY, documentWrapper.getJsonValue());
+                jsDocumentWrapper.putString(ETAG_KEY, documentWrapper.getETag());
 
                 // Pass milliseconds back to JS object since `WritableMap` does not support `Date` as values
-                jsDocumentWrapper.putDouble(LAST_UPDATED_DATE_FIELD, documentWrapper.getLastUpdatedDate().getTime());
-                jsDocumentWrapper.putBoolean(IS_FROM_DEVICE_CACHE_FIELD, documentWrapper.isFromDeviceCache());
-                jsDocumentWrapper.putString(ID_FIELD, documentWrapper.getId());
-                jsDocumentWrapper.putString(PARTITION_FIELD, documentWrapper.getPartition());
+                jsDocumentWrapper.putDouble(LAST_UPDATED_DATE_KEY, documentWrapper.getLastUpdatedDate().getTime());
+                jsDocumentWrapper.putBoolean(IS_FROM_DEVICE_CACHE_KEY, documentWrapper.isFromDeviceCache());
+                jsDocumentWrapper.putString(ID_KEY, documentWrapper.getId());
+                jsDocumentWrapper.putString(PARTITION_KEY, documentWrapper.getPartition());
                 if (deserializedValue.isJsonPrimitive()) {
                     JsonPrimitive jsonPrimitive = deserializedValue.getAsJsonPrimitive();
                     if (jsonPrimitive.isString()) {
-                        jsDocumentWrapper.putString(DESERIALIZED_VALUE_FIELD, jsonPrimitive.getAsString());
+                        jsDocumentWrapper.putString(DESERIALIZED_VALUE_KEY, jsonPrimitive.getAsString());
                     } else if (jsonPrimitive.isNumber()) {
-                        jsDocumentWrapper.putDouble(DESERIALIZED_VALUE_FIELD, jsonPrimitive.getAsDouble());
+                        jsDocumentWrapper.putDouble(DESERIALIZED_VALUE_KEY, jsonPrimitive.getAsDouble());
                     } else if (jsonPrimitive.isBoolean()) {
-                        jsDocumentWrapper.putBoolean(DESERIALIZED_VALUE_FIELD, jsonPrimitive.getAsBoolean());
+                        jsDocumentWrapper.putBoolean(DESERIALIZED_VALUE_KEY, jsonPrimitive.getAsBoolean());
                     }
                 } else if (deserializedValue.isJsonObject()) {
                     JsonObject jsonObject = deserializedValue.getAsJsonObject();
                     WritableMap writableMap = convertJsonObjectToWritableMap(jsonObject);
-                    jsDocumentWrapper.putMap(DESERIALIZED_VALUE_FIELD, writableMap);
+                    jsDocumentWrapper.putMap(DESERIALIZED_VALUE_KEY, writableMap);
                 } else if (deserializedValue.isJsonArray()) {
                     JsonArray jsonArray = deserializedValue.getAsJsonArray();
                     WritableArray writableArray = convertJsonArrayToWritableArray(jsonArray);
-                    jsDocumentWrapper.putArray(DESERIALIZED_VALUE_FIELD, writableArray);
+                    jsDocumentWrapper.putArray(DESERIALIZED_VALUE_KEY, writableArray);
                 } else {
-                    jsDocumentWrapper.putNull(DESERIALIZED_VALUE_FIELD);
+                    jsDocumentWrapper.putNull(DESERIALIZED_VALUE_KEY);
                 }
                 promise.resolve(jsDocumentWrapper);
             }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

[AB#62595](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/62595)
Modified `read` to return DocumentWrapper properties, specifically the following:
```
deserializedValue
partition
id
isFromDeviceCache
lastUpdatedDate
etag
jsonValue
```

lastUpdatedDate must be return as a milliseconds from Java and converted to a Date object in JavaScript. 
