### PR TITLE
[Fix] UI API called on background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Version 2.1.0 of the App Center React Native SDK includes a new module: Auth.
 * **[Fix]** Fix a crash when calling `Push.setEnabled` when `appcenter.json` contains both `"start_automatically": false` and `"enable_push_in_javascript": true`.
 * **[Fix]** Update Firebase dependency and AppCenter push logic to avoid a runtime issue with the latest Firebase messaging version 18.0.0.
 
+### iOS
+
+* **[Fix]** Fix calling UI API on background thread.
+
 ## Version 2.0.0
 
 Version 2.0.0 has a **breaking change**, it only supports Xcode 10.0.0+.

--- a/appcenter-push/ios/AppCenterReactNativePush/AppCenterReactNativePush.m
+++ b/appcenter-push/ios/AppCenterReactNativePush/AppCenterReactNativePush.m
@@ -97,15 +97,18 @@ RCT_EXPORT_METHOD(isEnabled : (RCTPromiseResolveBlock)resolve rejecter : (RCTPro
 }
 
 RCT_EXPORT_METHOD(setEnabled : (BOOL)shouldEnable resolver : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject) {
-  if (!startedPush && shouldEnable) {
-    [MSAppCenter startService:[MSPush class]];
-    startedPush = YES;
-  }
-  [MSPush setEnabled:shouldEnable];
-  if (shouldEnable) {
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kPushOnceEnabled];
-  }
-  resolve(nil);
+  // [UIApplication registerForRemoteNotifications] should be called from the main thread.
+  dispatch_async(dispatch_get_main_queue(), ^(void) {
+    if (!startedPush && shouldEnable) {
+      [MSAppCenter startService:[MSPush class]];
+      startedPush = YES;
+    }
+    [MSPush setEnabled:shouldEnable];
+    if (shouldEnable) {
+      [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kPushOnceEnabled];
+    }
+    resolve(nil);
+  });
 }
 
 RCT_EXPORT_METHOD(sendAndClearInitialNotification : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

ReactNative calls [MSPush setEnabled] from its worker thread, but [UIApplication registerForRemoteNotifications] should be called from UI Thread only.

## Related PRs or issues

[AB#63199](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/63199)
[Github issue](https://github.com/microsoft/appcenter-sdk-react-native/issues/598/)
