### PR TITLE
Implement `create` on Android

### DIFF
--- a/TestApp/app/screens/AppCenterScreen.js
+++ b/TestApp/app/screens/AppCenterScreen.js
@@ -258,7 +258,7 @@ export default class AppCenterScreen extends Component {
                       const result = await Auth.signIn();
                       this.setState({ accountId: result.accountId, isTokenSet: !!result.accessToken });
 
-                      runHardCodedDataCalls();
+                      runMBaaSCode();
                     } catch (e) {
                       console.log(e);
                     }
@@ -320,8 +320,7 @@ export default class AppCenterScreen extends Component {
   }
 }
 
-function runHardCodedDataCalls() {
-  /* Hard coded testing code */
+function runMBaaSCode() {
   const MY_DOCUMENT_ID = 'some-random-document-id';
   const readOptions = new Data.ReadOptions(5000);
   const writeOptions = new Data.WriteOptions(5000);

--- a/TestApp/app/screens/AppCenterScreen.js
+++ b/TestApp/app/screens/AppCenterScreen.js
@@ -9,6 +9,7 @@ import Toast from 'react-native-simple-toast';
 import AppCenter, { CustomProperties } from 'appcenter';
 import Auth from 'appcenter-auth';
 import Push from 'appcenter-push';
+import Data from 'appcenter-data';
 
 import SharedStyles from '../SharedStyles';
 import DialsTabBarIcon from '../assets/dials.png';
@@ -256,6 +257,8 @@ export default class AppCenterScreen extends Component {
                     try {
                       const result = await Auth.signIn();
                       this.setState({ accountId: result.accountId, isTokenSet: !!result.accessToken });
+
+                      runHardCodedDataCalls();
                     } catch (e) {
                       console.log(e);
                     }
@@ -315,4 +318,44 @@ export default class AppCenterScreen extends Component {
       </View>
     );
   }
+}
+
+function runHardCodedDataCalls() {
+  /* Hard coded testing code */
+  const MY_DOCUMENT_ID = 'some-random-document-id';
+  const readOptions = new Data.ReadOptions(5000);
+  const writeOptions = new Data.WriteOptions(5000);
+
+  const user = {
+    name: 'Alex',
+    email: 'alex@appcenter.ms',
+    phone: '+1-(855)-555-5555',
+    someNull: null,
+    nestedObject: {
+      nestedString: 'key1',
+      nestedBoolean: true,
+      nestedNumber: 42.2,
+      nestedArray: [1, 2, 3.0, 'four', '👻', null, true, false, { nestedCat: '😺' }]
+    },
+    someNumber: 26.1,
+    someOtherNumber: 26.0,
+    someBoolean: false,
+    '👻 as a key': '🤖'
+  };
+
+  Data.create(MY_DOCUMENT_ID, user, Data.DefaultPartitions.USER_DOCUMENTS, writeOptions).then((res) => {
+    console.log('Successful create');
+    console.log(res);
+  }).catch((err) => {
+    console.log('Failed create');
+    console.log(err);
+  });
+
+  Data.read(MY_DOCUMENT_ID, Data.DefaultPartitions.USER_DOCUMENTS, readOptions).then((res) => {
+    console.log('Successful read');
+    console.log(res);
+  }).catch((err) => {
+    console.log('Failed read');
+    console.log(err);
+  });
 }

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -40,7 +40,7 @@ function read(documentId, partition, readOptions) {
 }
 
 /**
- * Create a document
+ * Create a document.
  *
  * @param {string} documentId - The CosmosDB document id.
  * @param {object} document - The document.
@@ -69,7 +69,7 @@ Data.WriteOptions = class {
 };
 
 function convertTimestampToDate(result) {
-    if (!result === undefined || !result.lastUpdatedDate === undefined) {
+    if (result === undefined || result.lastUpdatedDate === undefined) {
         return result;
     }
     // Create a new `Date` object from timestamp as milliseconds.

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -69,6 +69,9 @@ Data.WriteOptions = class {
 };
 
 function convertTimestampToDate(result) {
+    if (!result === undefined || !result.lastUpdatedDate === undefined) {
+        return result;
+    }
     // Create a new `Date` object from timestamp as milliseconds.
     result.lastUpdatedDate = new Date(result.lastUpdatedDate);
     return result;

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -69,7 +69,7 @@ Data.WriteOptions = class {
 };
 
 function convertTimestampToDate(result) {
-    if (result === undefined || result.lastUpdatedDate === undefined) {
+    if (!result || !result.lastUpdatedDate) {
         return result;
     }
     // Create a new `Date` object from timestamp as milliseconds.

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -19,19 +19,42 @@ const DefaultPartitions = {
 const Data = {
     TimeToLive,
     DefaultPartitions,
-    read(documentId, partition, readOptions) {
-        if (readOptions === undefined) {
-            readOptions = new Data.ReadOptions(TimeToLive.DEFAULT);
-        }
-        return AppCenterReactNativeData.read(documentId, partition, readOptions).then(convertTimestampToDate);
-    },
-    create(documentId, document, partition, writeOptions) {
-        if (writeOptions === undefined) {
-            writeOptions = new Data.WriteOptions(TimeToLive.DEFAULT);
-        }
-        return AppCenterReactNativeData.create(documentId, document, partition, writeOptions).then(convertTimestampToDate);
-    }
+    read,
+    create
 };
+
+/**
+ * Read a document.
+ *
+ * @param {string} documentId - The CosmosDB document id.
+ * @param {string} partition - The CosmosDB partition key.
+ * @param {object} readOptions - Cache read options when the operation is done offline.
+ * @return {Promise} Future asynchronous operation with result being the document with metadata.
+ * If the operation fails, the error can be checked by reading the error object.
+ */
+function read(documentId, partition, readOptions) {
+    if (readOptions === undefined) {
+        readOptions = new Data.ReadOptions(TimeToLive.DEFAULT);
+    }
+    return AppCenterReactNativeData.read(documentId, partition, readOptions).then(convertTimestampToDate);
+}
+
+/**
+ * Create a document
+ *
+ * @param {string} documentId - The CosmosDB document id.
+ * @param {object} document - The document.
+ * @param {string} partition - The CosmosDB partition key.
+ * @param {object} writeOptions - Cache write options when the operation is done offline.
+ * @return {Promise} Future asynchronous operation with result being the document with metadata.
+ * If the operation fails, the error can be checked by reading the error object.
+ */
+function create(documentId, document, partition, writeOptions) {
+    if (writeOptions === undefined) {
+        writeOptions = new Data.WriteOptions(TimeToLive.DEFAULT);
+    }
+    return AppCenterReactNativeData.create(documentId, document, partition, writeOptions).then(convertTimestampToDate);
+}
 
 Data.ReadOptions = class {
     constructor(timeToLive) {
@@ -46,9 +69,11 @@ Data.WriteOptions = class {
 };
 
 function convertTimestampToDate(result) {
-    // Create a new `Date` object from timestamp as milliseconds
+    // Create a new `Date` object from timestamp as milliseconds.
     result.lastUpdatedDate = new Date(result.lastUpdatedDate);
     return result;
 }
+
+this.read();
 
 module.exports = Data;

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -23,11 +23,10 @@ const Data = {
         if (readOptions === undefined) {
             readOptions = new Data.ReadOptions(TimeToLive.DEFAULT);
         }
-        return AppCenterReactNativeData.read(documentId, partition, readOptions).then((result) => {
-            // Create a new `Date` object from timestamp as milliseconds
-            result.lastUpdatedDate = new Date(result.lastUpdatedDate);
-            return result;
-        });
+        return AppCenterReactNativeData.read(documentId, partition, readOptions).then(convertTimestampToDate);
+    },
+    create(documentId, document, partition) {
+        return AppCenterReactNativeData.create(documentId, document, partition).then(convertTimestampToDate);
     }
 };
 
@@ -36,5 +35,11 @@ Data.ReadOptions = class {
         this.timeToLive = timeToLive;
     }
 };
+
+function convertTimestampToDate(result) {
+    // Create a new `Date` object from timestamp as milliseconds
+    result.lastUpdatedDate = new Date(result.lastUpdatedDate);
+    return result;
+}
 
 module.exports = Data;

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -25,12 +25,21 @@ const Data = {
         }
         return AppCenterReactNativeData.read(documentId, partition, readOptions).then(convertTimestampToDate);
     },
-    create(documentId, document, partition) {
-        return AppCenterReactNativeData.create(documentId, document, partition).then(convertTimestampToDate);
+    create(documentId, document, partition, writeOptions) {
+        if (writeOptions === undefined) {
+            writeOptions = new Data.WriteOptions(TimeToLive.DEFAULT);
+        }
+        return AppCenterReactNativeData.create(documentId, document, partition, writeOptions).then(convertTimestampToDate);
     }
 };
 
 Data.ReadOptions = class {
+    constructor(timeToLive) {
+        this.timeToLive = timeToLive;
+    }
+};
+
+Data.WriteOptions = class {
     constructor(timeToLive) {
         this.timeToLive = timeToLive;
     }

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -30,7 +30,7 @@ const Data = {
  * @param {string} partition - The CosmosDB partition key.
  * @param {object} readOptions - Cache read options when the operation is done offline.
  * @return {Promise} Future asynchronous operation with result being the document with metadata.
- * If the operation fails, the error can be checked by reading the error object.
+ * If the operation fails, the promise is rejected with an exception containing the details of the error.
  */
 function read(documentId, partition, readOptions) {
     if (readOptions === undefined) {
@@ -47,7 +47,7 @@ function read(documentId, partition, readOptions) {
  * @param {string} partition - The CosmosDB partition key.
  * @param {object} writeOptions - Cache write options when the operation is done offline.
  * @return {Promise} Future asynchronous operation with result being the document with metadata.
- * If the operation fails, the error can be checked by reading the error object.
+ * If the operation fails, the promise is rejected with an exception containing the details of the error.
  */
 function create(documentId, document, partition, writeOptions) {
     if (writeOptions === undefined) {

--- a/appcenter-data/Data.js
+++ b/appcenter-data/Data.js
@@ -74,6 +74,4 @@ function convertTimestampToDate(result) {
     return result;
 }
 
-this.read();
-
 module.exports = Data;

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
@@ -72,7 +72,7 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
     }
 
     @ReactMethod
-    public void create(final String documentId, ReadableMap readableMap, String partition, ReadableMap writeOptionsMap, final Promise promise) {
+    public void create(String documentId, ReadableMap readableMap, String partition, ReadableMap writeOptionsMap, final Promise promise) {
         WriteOptions writeOptions;
         if (writeOptionsMap.hasKey(TIME_TO_LIVE_KEY)) {
             writeOptions = new WriteOptions(writeOptionsMap.getInt(TIME_TO_LIVE_KEY));

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
@@ -26,6 +26,7 @@ import com.microsoft.appcenter.data.TimeToLive;
 import com.microsoft.appcenter.data.exception.DataException;
 import com.microsoft.appcenter.data.models.DocumentWrapper;
 import com.microsoft.appcenter.data.models.ReadOptions;
+import com.microsoft.appcenter.data.models.WriteOptions;
 import com.microsoft.appcenter.reactnative.shared.AppCenterReactNativeShared;
 import com.microsoft.appcenter.utils.async.AppCenterConsumer;
 
@@ -71,9 +72,15 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
     }
 
     @ReactMethod
-    public void create(final String documentId, ReadableMap readableMap, String partition, final Promise promise) {
+    public void create(final String documentId, ReadableMap readableMap, String partition, ReadableMap writeOptionsMap, final Promise promise) {
+        WriteOptions writeOptions;
+        if (writeOptionsMap.hasKey(TIME_TO_LIVE_KEY)) {
+            writeOptions = new WriteOptions(writeOptionsMap.getInt(TIME_TO_LIVE_KEY));
+        } else {
+            writeOptions = new WriteOptions(TimeToLive.DEFAULT);
+        }
         JsonObject jsonObject = AppCenterReactNativeDataUtils.convertReadableMapToJsonObject(readableMap);
-        Data.create(documentId, jsonObject, JsonElement.class, partition).thenAccept(new Consumer("Create failed", promise));
+        Data.create(documentId, jsonObject, JsonElement.class, partition, writeOptions).thenAccept(new Consumer("Create failed", promise));
     }
 
     private class Consumer implements AppCenterConsumer<DocumentWrapper<JsonElement>> {

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataModule.java
@@ -84,12 +84,14 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
     }
 
     private class Consumer implements AppCenterConsumer<DocumentWrapper<JsonElement>> {
-        private Promise promise;
-        private String errorCode;
 
-        private Consumer(String errorCode, final Promise promise) {
-            this.promise = promise;
-            this.errorCode = errorCode;
+        private Promise mPromise;
+
+        private String mErrorCode;
+
+        private Consumer(String errorCode, Promise promise) {
+            mPromise = promise;
+            mErrorCode = errorCode;
         }
 
         @Override
@@ -100,13 +102,13 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
             jsDocumentWrapper.putString(PARTITION_KEY, documentWrapper.getPartition());
             if (documentWrapper.getError() != null) {
                 DataException dataException = documentWrapper.getError();
-                promise.reject(errorCode, dataException.getMessage(), dataException, jsDocumentWrapper);
+                mPromise.reject(mErrorCode, dataException.getMessage(), dataException, jsDocumentWrapper);
                 return;
             }
             JsonElement deserializedValue = documentWrapper.getDeserializedValue();
             jsDocumentWrapper.putString(JSON_VALUE_KEY, documentWrapper.getJsonValue());
 
-            // Pass milliseconds back to JS object since `WritableMap` does not support `Date` as values
+            /* Pass milliseconds back to JS object since `WritableMap` does not support `Date` as values. */
             jsDocumentWrapper.putDouble(LAST_UPDATED_DATE_KEY, documentWrapper.getLastUpdatedDate().getTime());
             jsDocumentWrapper.putBoolean(IS_FROM_DEVICE_CACHE_KEY, documentWrapper.isFromDeviceCache());
             if (deserializedValue.isJsonPrimitive()) {
@@ -129,7 +131,7 @@ public class AppCenterReactNativeDataModule extends BaseJavaModule {
             } else {
                 jsDocumentWrapper.putNull(DESERIALIZED_VALUE_KEY);
             }
-            promise.resolve(jsDocumentWrapper);
+            mPromise.resolve(jsDocumentWrapper);
         }
     }
 }

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataUtils.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataUtils.java
@@ -3,6 +3,10 @@
 
 package com.microsoft.appcenter.reactnative.data;
 
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
@@ -10,11 +14,12 @@ import com.facebook.react.bridge.WritableNativeMap;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
 public class AppCenterReactNativeDataUtils {
-    
+
     public static WritableMap convertJsonObjectToWritableMap(JsonObject jsonObject) {
         WritableMap writableMap = new WritableNativeMap();
         for (String key : jsonObject.keySet()) {
@@ -63,5 +68,68 @@ public class AppCenterReactNativeDataUtils {
             }
         }
         return writableArray;
+    }
+
+    public static JsonObject convertReadableMapToJsonObject(ReadableMap readableMap) {
+        JsonObject jsonObject = new JsonObject();
+        if (readableMap == null) {
+            return jsonObject;
+        }
+        ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
+        while (iterator.hasNextKey()) {
+            String key = iterator.nextKey();
+            ReadableType type = readableMap.getType(key);
+            switch (type) {
+                case Number:
+                    jsonObject.addProperty(key, readableMap.getDouble(key));
+                    break;
+                case String:
+                    jsonObject.addProperty(key, readableMap.getString(key));
+                    break;
+                case Boolean:
+                    jsonObject.addProperty(key, readableMap.getBoolean(key));
+                    break;
+                case Map:
+                    jsonObject.add(key, convertReadableMapToJsonObject(readableMap.getMap(key)));
+                    break;
+                case Array:
+                    jsonObject.add(key, convertReadableArrayToJsonArray(readableMap.getArray(key)));
+                    break;
+                default:
+                    break;
+            }
+        }
+        return jsonObject;
+    }
+
+    public static JsonArray convertReadableArrayToJsonArray(ReadableArray readableArray) {
+        JsonArray jsonArray = new JsonArray();
+        if (readableArray == null) {
+            return jsonArray;
+        }
+        for (int i = 0; i < readableArray.size(); i++) {
+            ReadableType type = readableArray.getType(i);
+            switch (type) {
+                case Number:
+                    jsonArray.add(readableArray.getDouble(i));
+                    break;
+                case String:
+                    jsonArray.add(readableArray.getString(i));
+                    break;
+                case Boolean:
+                    jsonArray.add(readableArray.getBoolean(i));
+                    break;
+                case Map:
+                    jsonArray.add(convertReadableMapToJsonObject(readableArray.getMap(i)));
+                    break;
+                case Array:
+                    jsonArray.add(convertReadableArrayToJsonArray(readableArray.getArray(i)));
+                    break;
+                default:
+                    jsonArray.add(JsonNull.INSTANCE);
+                    break;
+            }
+        }
+        return jsonArray;
     }
 }

--- a/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataUtils.java
+++ b/appcenter-data/android/src/main/java/com/microsoft/appcenter/reactnative/data/AppCenterReactNativeDataUtils.java
@@ -96,6 +96,7 @@ public class AppCenterReactNativeDataUtils {
                     jsonObject.add(key, convertReadableArrayToJsonArray(readableMap.getArray(key)));
                     break;
                 default:
+                    jsonObject.add(key, JsonNull.INSTANCE);
                     break;
             }
         }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
[AB#62463](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/62463)
- Implemented `create` for React Native Android.
- Added `WriteOptions` for `create`
- Created helper functions, `convertReadableMapToJsonObject` and `convertReadableArrayToJsonArray` to convert JS to Java JSON Objects
- Create a private `Consumer` class that implements `AppCenterConsumer` to handle callbacks for `read` and create`

