### PR TITLE
remove postlink from *.config.js

### DIFF
--- a/appcenter-analytics/react-native.config.js
+++ b/appcenter-analytics/react-native.config.js
@@ -4,11 +4,7 @@ module.exports = {
       ios: {},
       android: {
         packageInstance: 'new AppCenterReactNativeAnalyticsPackage(getApplication(), getResources().getString(R.string.appCenterAnalytics_whenToEnableAnalytics))'
-      },
-    },
-    assets: [],
-    hooks: {
-      postlink: './node_modules/appcenter-analytics/scripts/postlink'
+      }
     }
-  },
+  }
 };

--- a/appcenter-auth/react-native.config.js
+++ b/appcenter-auth/react-native.config.js
@@ -4,11 +4,7 @@ module.exports = {
       ios: {},
       android: {
         packageInstance: 'new AppCenterReactNativeAuthPackage(getApplication())'
-      },
-    },
-    assets: [],
-    hooks: {
-      postlink: './node_modules/appcenter-auth/scripts/postlink'
+      }
     }
-  },
+  }
 };

--- a/appcenter-crashes/react-native.config.js
+++ b/appcenter-crashes/react-native.config.js
@@ -4,11 +4,7 @@ module.exports = {
       ios: {},
       android: {
         packageInstance: 'new AppCenterReactNativeCrashesPackage(getApplication(), getResources().getString(R.string.appCenterCrashes_whenToSendCrashes))'
-      },
-    },
-    assets: [],
-    hooks: {
-      postlink: './node_modules/appcenter-crashes/scripts/postlink'
+      }
     }
-  },
+  }
 };

--- a/appcenter-push/react-native.config.js
+++ b/appcenter-push/react-native.config.js
@@ -4,11 +4,7 @@ module.exports = {
       ios: {},
       android: {
         packageInstance: 'new AppCenterReactNativePushPackage(getApplication())'
-      },
-    },
-    assets: [],
-    hooks: {
-      postlink: './node_modules/appcenter-push/scripts/postlink'
+      }
     }
-  },
+  }
 };

--- a/appcenter/react-native.config.js
+++ b/appcenter/react-native.config.js
@@ -4,11 +4,7 @@ module.exports = {
       ios: {},
       android: {
         packageInstance: 'new AppCenterReactNativePackage(getApplication())'
-      },
-    },
-    assets: [],
-    hooks: {
-      postlink: './node_modules/appcenter/scripts/postlink'
+      }
     }
-  },
+  }
 };


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

[AB#63350](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63350)

We are moving a lot of work from our postlink scripts to react-native config.
Thus, we need to remove the part working with dependencies from the postlink scripts in each module.

Implementation details:
• Postlink scripts are located under the scripts folder in each of the modules. Common scripts are in the appcenter-link-scripts module.
• We need to completely remove the part working with Podfile from our postlink scripts.
• Autolinking doesn't work with postlink scripts. There is a feature request to support that but it's unlikely to be shipped with one of the first 0.60 releases: https://github.com/react-native-community/cli/issues/429. So don't forget to run it manually for now.

A few sentences describing the overall goals of the pull request.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
