### PR TITLE
Add auth_provider config in RN.Android

### DIFF
--- a/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
+++ b/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
@@ -61,17 +61,13 @@ public class AppCenterReactNativeShared {
             sAppSecret = sConfiguration.optString(APP_SECRET_KEY);
             sStartAutomatically = sConfiguration.optBoolean(START_AUTOMATICALLY_KEY, true);
         }
-        String authProvider = sConfiguration.optString(AUTH_PROVIDER);
-        String authProviderLowerCase = authProvider.toLowerCase();
-        if (authProviderLowerCase.equals(AUTH0.toLowerCase())
-                || authProviderLowerCase.equals(FIREBASE.toLowerCase())
-                || authProviderLowerCase.equals(AAD_B2C.toLowerCase())) {
 
-            /*
-             * When sStartAutomatically flag is set to true, every service (analytics/auth/crashes/etc.)
-             * will be started by separate AppCenter.start call. Since App Center Auth is used,
-             * we call doNotResetAuthAfterStart to avoid resetting the auth token.
-             */
+        /*
+         * When sStartAutomatically flag is set to true, every service (analytics/auth/crashes/etc.)
+         * will be started by separate AppCenter.start call. If any auth provider is used,
+         * we should call doNotResetAuthAfterStart to avoid resetting the auth token.
+         */
+        if (authProviderExistsInConfigFile()) {
             AuthTokenContext.getInstance().doNotResetAuthAfterStart();
         }
         if (!sStartAutomatically) {
@@ -119,5 +115,12 @@ public class AppCenterReactNativeShared {
 
     public static synchronized void setStartAutomatically(boolean startAutomatically) {
         sStartAutomatically = startAutomatically;
+    }
+
+    private static boolean authProviderExistsInConfigFile() {
+        String authProviderLowerCase = sConfiguration.optString(AUTH_PROVIDER).toLowerCase();
+        return authProviderLowerCase.equals(AUTH0.toLowerCase())
+                || authProviderLowerCase.equals(FIREBASE.toLowerCase())
+                || authProviderLowerCase.equals(AAD_B2C.toLowerCase());
     }
 }

--- a/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
+++ b/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
@@ -49,9 +49,6 @@ public class AppCenterReactNativeShared {
         sApplication = application;
         if (sConfiguration == null) {
             readConfigurationFile(application);
-            if (sConfiguration == null) {
-                return;
-            }
         }
         WrapperSdk wrapperSdk = new WrapperSdk();
         wrapperSdk.setWrapperSdkVersion(com.microsoft.appcenter.reactnative.shared.BuildConfig.VERSION_NAME);
@@ -104,7 +101,7 @@ public class AppCenterReactNativeShared {
             sConfiguration = new JSONObject(jsonContents);
         } catch (Exception e) {
             AppCenterLog.error(LOG_TAG, "Failed to parse appcenter-config.json", e);
-            sConfiguration = null;
+            sConfiguration = new JSONObject();
         }
         return sConfiguration;
     }

--- a/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
+++ b/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
@@ -47,16 +47,19 @@ public class AppCenterReactNativeShared {
             return;
         }
         sApplication = application;
+        if (sConfiguration == null) {
+            readConfigurationFile(application);
+            if (sConfiguration == null) {
+                return;
+            }
+        }
         WrapperSdk wrapperSdk = new WrapperSdk();
         wrapperSdk.setWrapperSdkVersion(com.microsoft.appcenter.reactnative.shared.BuildConfig.VERSION_NAME);
         wrapperSdk.setWrapperSdkName(com.microsoft.appcenter.reactnative.shared.BuildConfig.SDK_NAME);
         AppCenter.setWrapperSdk(wrapperSdk);
-        if (sConfiguration == null) {
-            readConfigurationFile(application);
-            if (sAppSecret == null) {
-                sAppSecret = sConfiguration.optString(APP_SECRET_KEY);
-                sStartAutomatically = sConfiguration.optBoolean(START_AUTOMATICALLY_KEY, true);
-            }
+        if (sAppSecret == null) {
+            sAppSecret = sConfiguration.optString(APP_SECRET_KEY);
+            sStartAutomatically = sConfiguration.optBoolean(START_AUTOMATICALLY_KEY, true);
         }
         String authProvider = sConfiguration.optString(AUTH_PROVIDER);
         String authProviderLowerCase = authProvider.toLowerCase();
@@ -89,6 +92,9 @@ public class AppCenterReactNativeShared {
     }
 
     public static synchronized JSONObject readConfigurationFile(Application application) {
+        if (sConfiguration != null) {
+            return sConfiguration;
+        }
         try {
             AppCenterLog.debug(LOG_TAG, "Reading " + APPCENTER_CONFIG_ASSET);
             InputStream configStream = application.getAssets().open(APPCENTER_CONFIG_ASSET);
@@ -102,7 +108,7 @@ public class AppCenterReactNativeShared {
             sConfiguration = new JSONObject(jsonContents);
         } catch (Exception e) {
             AppCenterLog.error(LOG_TAG, "Failed to parse appcenter-config.json", e);
-            sConfiguration = new JSONObject();
+            sConfiguration = null;
         }
         return sConfiguration;
     }
@@ -113,9 +119,5 @@ public class AppCenterReactNativeShared {
 
     public static synchronized void setStartAutomatically(boolean startAutomatically) {
         sStartAutomatically = startAutomatically;
-    }
-
-    public static synchronized JSONObject getConfiguration() {
-        return sConfiguration;
     }
 }

--- a/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
+++ b/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
@@ -4,6 +4,7 @@
 package com.microsoft.appcenter.reactnative.shared;
 
 import android.app.Application;
+import android.content.Context;
 import android.text.TextUtils;
 
 import com.microsoft.appcenter.AppCenter;
@@ -48,7 +49,7 @@ public class AppCenterReactNativeShared {
         }
         sApplication = application;
         if (sConfiguration == null) {
-            readConfigurationFile(application);
+            readConfigurationFile(application.getApplicationContext());
         }
         WrapperSdk wrapperSdk = new WrapperSdk();
         wrapperSdk.setWrapperSdkVersion(com.microsoft.appcenter.reactnative.shared.BuildConfig.VERSION_NAME);
@@ -84,13 +85,14 @@ public class AppCenterReactNativeShared {
         }
     }
 
-    public static synchronized JSONObject readConfigurationFile(Application application) {
+    public static synchronized JSONObject readConfigurationFile(Context context) {
         if (sConfiguration != null) {
             return sConfiguration;
         }
         try {
             AppCenterLog.debug(LOG_TAG, "Reading " + APPCENTER_CONFIG_ASSET);
-            InputStream configStream = application.getAssets().open(APPCENTER_CONFIG_ASSET);
+
+            InputStream configStream = context.getAssets().open(APPCENTER_CONFIG_ASSET);
             int size = configStream.available();
             byte[] buffer = new byte[size];
 

--- a/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
+++ b/AppCenterReactNativeShared/android/src/main/java/com/microsoft/appcenter/reactnative/shared/AppCenterReactNativeShared.java
@@ -65,7 +65,7 @@ public class AppCenterReactNativeShared {
          * will be started by separate AppCenter.start call. If any auth provider is used,
          * we should call doNotResetAuthAfterStart to avoid resetting the auth token.
          */
-        if (authProviderExistsInConfigFile()) {
+        if (validAuthProviderInConfigFile()) {
             AuthTokenContext.getInstance().doNotResetAuthAfterStart();
         }
         if (!sStartAutomatically) {
@@ -91,7 +91,6 @@ public class AppCenterReactNativeShared {
         }
         try {
             AppCenterLog.debug(LOG_TAG, "Reading " + APPCENTER_CONFIG_ASSET);
-
             InputStream configStream = context.getAssets().open(APPCENTER_CONFIG_ASSET);
             int size = configStream.available();
             byte[] buffer = new byte[size];
@@ -102,7 +101,7 @@ public class AppCenterReactNativeShared {
             String jsonContents = new String(buffer, "UTF-8");
             sConfiguration = new JSONObject(jsonContents);
         } catch (Exception e) {
-            AppCenterLog.error(LOG_TAG, "Failed to parse appcenter-config.json", e);
+            AppCenterLog.error(LOG_TAG, "Failed to parse appcenter-config.json.", e);
             sConfiguration = new JSONObject();
         }
         return sConfiguration;
@@ -116,10 +115,20 @@ public class AppCenterReactNativeShared {
         sStartAutomatically = startAutomatically;
     }
 
-    private static boolean authProviderExistsInConfigFile() {
-        String authProviderLowerCase = sConfiguration.optString(AUTH_PROVIDER).toLowerCase();
-        return authProviderLowerCase.equals(AUTH0.toLowerCase())
+    private static boolean validAuthProviderInConfigFile() {
+        String authProvider = sConfiguration.optString(AUTH_PROVIDER);
+        if (authProvider.length() == 0) {
+            return false;
+        }
+        String authProviderLowerCase = authProvider.toLowerCase();
+        boolean authProviderIsValid = authProviderLowerCase.equals(AUTH0.toLowerCase())
                 || authProviderLowerCase.equals(FIREBASE.toLowerCase())
                 || authProviderLowerCase.equals(AAD_B2C.toLowerCase());
+        if (authProviderIsValid) {
+            AppCenterLog.debug(LOG_TAG, AUTH_PROVIDER + ": " + authProvider + " found in appcenter-config.json.");
+        } else {
+            AppCenterLog.error(LOG_TAG, "Invalid " + AUTH_PROVIDER + ": " + authProvider + " in appcenter-config.json.");
+        }
+        return authProviderIsValid;
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for React Native Change Log
 
+## Version 2.5.0 (Under active development)
+
+### App Center Auth
+
+#### Android
+
+* **[Android Breaking Change]** App Center Android Auth now requires a new config `auth_provider` in **appcenter-config.json** file. Valid auth provider values are `AADB2C`, `FireBase` and `Auth0`. For more information of setting up Auth, please follow [App Center Auth documentation](https://docs.microsoft.com/en-us/appcenter/sdk/auth/react-native).
+
 ## Version 2.4.0 (Under active development)
 
 ### App Center

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Android
 
-* **[Android Breaking Change]** App Center Android Auth now requires a new config `auth_provider` in **appcenter-config.json** file. Valid auth provider values are `AADB2C`, `FireBase` and `Auth0`. For more information of setting up Auth, please follow [App Center Auth documentation](https://docs.microsoft.com/en-us/appcenter/sdk/auth/react-native).
+* **[Breaking Change]** App Center Android Auth now requires a new config `auth_provider` in **appcenter-config.json** file. Valid auth provider values are `AADB2C`, `FireBase` and `Auth0`. For more information of setting up Auth, please follow [App Center Auth documentation](https://docs.microsoft.com/en-us/appcenter/sdk/auth/react-native).
 
 ## Version 2.4.0 (Under active development)
 

--- a/TestApp/android/app/src/main/assets/appcenter-config.json
+++ b/TestApp/android/app/src/main/assets/appcenter-config.json
@@ -1,4 +1,5 @@
 {
     "app_secret": "32fcfc69-d576-41dc-8d49-4be159e3d7b2",
+    "auth_provider": "AADB2C",
     "enable_push_in_javascript": true
 }

--- a/appcenter-analytics/android/build.gradle
+++ b/appcenter-analytics/android/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     api 'com.microsoft.appcenter:appcenter-analytics:2.3.0'
 
-    //api project(':AppCenterReactNativeShared')   // For testing with TestApp
-    api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
+    api project(':AppCenterReactNativeShared')   // For testing with TestApp
+    //api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
 }

--- a/appcenter-auth/android/build.gradle
+++ b/appcenter-auth/android/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     api 'com.microsoft.appcenter:appcenter-auth:2.3.0'
 
-    //api project(':AppCenterReactNativeShared')   // For testing with TestApp
-    api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
+    api project(':AppCenterReactNativeShared')   // For testing with TestApp
+    //api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
 }

--- a/appcenter-crashes/android/build.gradle
+++ b/appcenter-crashes/android/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     api 'com.microsoft.appcenter:appcenter-crashes:2.3.0'
 
-    //api project(':AppCenterReactNativeShared')   // For testing with TestApp
-    api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
+    api project(':AppCenterReactNativeShared')   // For testing with TestApp
+    //api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
 }

--- a/appcenter-data/android/build.gradle
+++ b/appcenter-data/android/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     api 'com.microsoft.appcenter:appcenter-data:2.2.0'
 
-    //api project(':AppCenterReactNativeShared')   // For testing with TestApp
-    api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.2.0'
+    api project(':AppCenterReactNativeShared')   // For testing with TestApp
+    //api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.2.0'
 }

--- a/appcenter-push/android/build.gradle
+++ b/appcenter-push/android/build.gradle
@@ -35,6 +35,6 @@ dependencies {
         api "com.android.support:support-v4:${supportLibVersion}"
     }
 
-    //api project(':AppCenterReactNativeShared')   // For testing with TestApp
-    api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
+    api project(':AppCenterReactNativeShared')   // For testing with TestApp
+    //api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
 }

--- a/appcenter-push/android/src/main/java/com/microsoft/appcenter/reactnative/push/AppCenterReactNativePushModule.java
+++ b/appcenter-push/android/src/main/java/com/microsoft/appcenter/reactnative/push/AppCenterReactNativePushModule.java
@@ -35,7 +35,7 @@ public class AppCenterReactNativePushModule extends BaseJavaModule {
         AppCenterReactNativeShared.configureAppCenter(application);
         if (AppCenter.isConfigured()) {
             boolean startPush = true;
-            boolean enablePushInJavascript = AppCenterReactNativeShared.readConfigurationFile(application).optBoolean(ENABLE_PUSH_IN_JAVASCRIPT);
+            boolean enablePushInJavascript = AppCenterReactNativeShared.readConfigurationFile(application.getApplicationContext()).optBoolean(ENABLE_PUSH_IN_JAVASCRIPT);
             if (enablePushInJavascript) {
 
                 /*

--- a/appcenter-push/android/src/main/java/com/microsoft/appcenter/reactnative/push/AppCenterReactNativePushModule.java
+++ b/appcenter-push/android/src/main/java/com/microsoft/appcenter/reactnative/push/AppCenterReactNativePushModule.java
@@ -35,7 +35,7 @@ public class AppCenterReactNativePushModule extends BaseJavaModule {
         AppCenterReactNativeShared.configureAppCenter(application);
         if (AppCenter.isConfigured()) {
             boolean startPush = true;
-            boolean enablePushInJavascript = AppCenterReactNativeShared.getConfiguration().optBoolean(ENABLE_PUSH_IN_JAVASCRIPT);
+            boolean enablePushInJavascript = AppCenterReactNativeShared.readConfigurationFile(application).optBoolean(ENABLE_PUSH_IN_JAVASCRIPT);
             if (enablePushInJavascript) {
 
                 /*

--- a/appcenter/android/build.gradle
+++ b/appcenter/android/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     api 'com.microsoft.appcenter:appcenter:2.3.0'
 
-    //api project(':AppCenterReactNativeShared')   // For testing with TestApp
-    api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
+    api project(':AppCenterReactNativeShared')   // For testing with TestApp
+    //api 'com.microsoft.appcenter.reactnative:appcenter-react-native:2.3.0'
 }

--- a/appcenter/android/src/main/java/com/microsoft/appcenter/reactnative/appcenter/AppCenterReactNativeModule.java
+++ b/appcenter/android/src/main/java/com/microsoft/appcenter/reactnative/appcenter/AppCenterReactNativeModule.java
@@ -30,7 +30,7 @@ public class AppCenterReactNativeModule extends BaseJavaModule {
     private static final String FIREBASE = "Firebase";
 
     public AppCenterReactNativeModule(Application application) {
-        String authProvider = AppCenterReactNativeShared.getConfiguration().optString(AUTH_PROVIDER);
+        String authProvider = AppCenterReactNativeShared.readConfigurationFile(application).optString(AUTH_PROVIDER);
         String authProviderLowerCase = authProvider.toLowerCase();
         if (authProviderLowerCase.equals(AUTH0.toLowerCase()) || authProviderLowerCase.equals(FIREBASE.toLowerCase())) {
             // TODO: AppCenter.setAuthTokenListener(mAppCenterListener)

--- a/appcenter/android/src/main/java/com/microsoft/appcenter/reactnative/appcenter/AppCenterReactNativeModule.java
+++ b/appcenter/android/src/main/java/com/microsoft/appcenter/reactnative/appcenter/AppCenterReactNativeModule.java
@@ -23,7 +23,18 @@ public class AppCenterReactNativeModule extends BaseJavaModule {
 
     private final Application mApplication;
 
+    private static final String AUTH_PROVIDER = "auth_provider";
+
+    private static final String AUTH0 = "Auth0";
+
+    private static final String FIREBASE = "Firebase";
+
     public AppCenterReactNativeModule(Application application) {
+        String authProvider = AppCenterReactNativeShared.getConfiguration().optString(AUTH_PROVIDER);
+        String authProviderLowerCase = authProvider.toLowerCase();
+        if (authProviderLowerCase.equals(AUTH0.toLowerCase()) || authProviderLowerCase.equals(FIREBASE.toLowerCase())) {
+            // TODO: AppCenter.setAuthTokenListener(mAppCenterListener)
+        }
         mApplication = application;
         AppCenterReactNativeShared.configureAppCenter(application);
     }

--- a/appcenter/android/src/main/java/com/microsoft/appcenter/reactnative/appcenter/AppCenterReactNativeModule.java
+++ b/appcenter/android/src/main/java/com/microsoft/appcenter/reactnative/appcenter/AppCenterReactNativeModule.java
@@ -30,7 +30,7 @@ public class AppCenterReactNativeModule extends BaseJavaModule {
     private static final String FIREBASE = "Firebase";
 
     public AppCenterReactNativeModule(Application application) {
-        String authProvider = AppCenterReactNativeShared.readConfigurationFile(application).optString(AUTH_PROVIDER);
+        String authProvider = AppCenterReactNativeShared.readConfigurationFile(application.getApplicationContext()).optString(AUTH_PROVIDER);
         String authProviderLowerCase = authProvider.toLowerCase();
         if (authProviderLowerCase.equals(AUTH0.toLowerCase()) || authProviderLowerCase.equals(FIREBASE.toLowerCase())) {
             // TODO: AppCenter.setAuthTokenListener(mAppCenterListener)


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

[RN.Android] Introduce `auth_provider` entry in appcenter-config.json. The value can be one of these 3 values: "AADB2C", "Auth0" and "Firebase" for now.

Sample appcenter-config.json:
```json
{
    "app_secret": "{appsecret}",
    "auth_provider": "AADB2C",
    "enable_push_in_javascript": true
}
```

## Related PRs or issues

[AB#67957](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/67957)