### PR TITLE
Data switch button is still displayed enabled after switching App Center disabled

### DIFF
--- a/DemoApp/app/screens/DataScreen.js
+++ b/DemoApp/app/screens/DataScreen.js
@@ -16,9 +16,9 @@ export default class DataScreen extends Component {
     tabBarIcon: () => <Image style={{ width: 24, height: 24 }} source={DataTabBarIcon} />,
     tabBarOnPress: ({ defaultHandler, navigation }) => {
       // Allow consequent presses to refresh the screen.
-      const refreshScreen = navigation.getParam('refreshScreen');
-      if (refreshScreen) {
-        refreshScreen();
+      const refreshData = navigation.getParam('refreshData');
+      if (refreshData) {
+        refreshData();
       }
       defaultHandler();
     }
@@ -44,7 +44,7 @@ export default class DataScreen extends Component {
 
     // Add a way to refresh the screen when the tab is pressed.
     this.props.navigation.setParams({
-      refreshScreen: this.refreshToggle.bind(this)
+      refreshData: this.refreshToggle.bind(this)
     });
     const documents = await this.listDocuments(this.state.partition);
     this.setState({ documents, loadingData: false });

--- a/DemoApp/app/screens/DataScreen.js
+++ b/DemoApp/app/screens/DataScreen.js
@@ -16,7 +16,7 @@ export default class DataScreen extends Component {
     tabBarIcon: () => <Image style={{ width: 24, height: 24 }} source={DataTabBarIcon} />,
     tabBarOnPress: ({ defaultHandler, navigation }) => {
       // Allow consequent presses to refresh the screen.
-      const refreshScreen = navigation.getParam('refreshData');
+      const refreshScreen = navigation.getParam('refreshScreen');
       if (refreshScreen) {
         refreshScreen();
       }

--- a/TestApp/app/screens/DataScreen.js
+++ b/TestApp/app/screens/DataScreen.js
@@ -16,9 +16,9 @@ export default class DataScreen extends Component {
     tabBarIcon: () => <Image style={{ width: 24, height: 24 }} source={DataTabBarIcon} />,
     tabBarOnPress: ({ defaultHandler, navigation }) => {
       // Allow consequent presses to refresh the screen.
-      const refreshScreen = navigation.getParam('refreshScreen');
-      if (refreshScreen) {
-        refreshScreen();
+      const refreshData = navigation.getParam('refreshData');
+      if (refreshData) {
+        refreshData();
       }
       defaultHandler();
     }
@@ -44,7 +44,7 @@ export default class DataScreen extends Component {
 
     // Add a way to refresh the screen when the tab is pressed.
     this.props.navigation.setParams({
-      refreshScreen: this.refreshToggle.bind(this)
+      refreshData: this.refreshToggle.bind(this)
     });
     const documents = await this.listDocuments(this.state.partition);
     this.setState({ documents, loadingData: false });

--- a/TestApp/app/screens/DataScreen.js
+++ b/TestApp/app/screens/DataScreen.js
@@ -16,7 +16,7 @@ export default class DataScreen extends Component {
     tabBarIcon: () => <Image style={{ width: 24, height: 24 }} source={DataTabBarIcon} />,
     tabBarOnPress: ({ defaultHandler, navigation }) => {
       // Allow consequent presses to refresh the screen.
-      const refreshScreen = navigation.getParam('refreshData');
+      const refreshScreen = navigation.getParam('refreshScreen');
       if (refreshScreen) {
         refreshScreen();
       }


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Data switch button is still displayed enabled after switching App Center disabled

## Related PRs or issues
[#AB69665](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Yoann-Team/Backlog%20Items/?workitem=69665)