### PR TITLE
Add exact version of rnfs

### DIFF
--- a/DemoApp/package.json
+++ b/DemoApp/package.json
@@ -18,7 +18,7 @@
     "metro": "^0.54.1",
     "react": "16.8.3",
     "react-native": "0.59.9",
-    "react-native-fs": "2.9.10",
+    "react-native-fs": "2.9.12",
     "react-native-gesture-handler": "~1.1.0",
     "react-native-image-picker": "^0.28.0",
     "react-native-modal-selector": "^1.0.2",

--- a/DemoApp/package.json
+++ b/DemoApp/package.json
@@ -18,7 +18,7 @@
     "metro": "^0.54.1",
     "react": "16.8.3",
     "react-native": "0.59.9",
-    "react-native-fs": "^2.9.12",
+    "react-native-fs": "2.9.10",
     "react-native-gesture-handler": "~1.1.0",
     "react-native-image-picker": "^0.28.0",
     "react-native-modal-selector": "^1.0.2",


### PR DESCRIPTION
In latest versions of RN, `RCTImageLoader.h` import was deprecated. RNFS module created a patch replacing this import with a new one, `RCTImageLoaderProtocol.h`. But we test backwards compatibility on RN 0.59.9 and it breaks archive for us.

Therefore, I had to specify the exact `RNFS` version *without* this change.