### PR TITLE
Resolved vulnerability in mkdirp dependency

### DIFF
--- a/appcenter-link-scripts/package.json
+++ b/appcenter-link-scripts/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "debug": "4.1.1",
     "glob": "5.0.15",
-    "mkdirp": "0.5.1",
+    "mkdirp": "0.5.3",
     "plist": "3.0.1",
     "which": "1.2.11",
     "xcode": "2.0.0"


### PR DESCRIPTION
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=0.2.1 <1.0.0 || >=1.2.3                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ appcenter                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ appcenter > appcenter-link-scripts > mkdirp > minimist       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1179                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

## Description

This PR seeks to fix the vulnerability discovered in the mkdirp package appcenter depends on. See advisory for details.
