### PR TITLE
Fork mirror: Resolved vulnerability in mkdirp dependency

### DIFF
--- a/appcenter-link-scripts/package.json
+++ b/appcenter-link-scripts/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "debug": "4.1.1",
     "glob": "5.0.15",
-    "mkdirp": "0.5.1",
+    "mkdirp": "0.5.3",
     "plist": "3.0.1",
     "which": "1.2.11",
     "xcode": "2.0.0"


### PR DESCRIPTION
Just mirror for #812 builds, please review and approve the original, not this one.
In case of new commits:

```
git checkout fix/vuln-deps
git fetch origin refs/pull/812/head
git reset --hard FETCH_HEAD
git push --force
```