### PR TITLE
Add explicit react-native-screens dependency to the TestApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ local.properties
 *.class
 *.project
 *.prefs
+.classpath
 
 # node.js
 #

--- a/TestApp/ios/Podfile.lock
+++ b/TestApp/ios/Podfile.lock
@@ -377,7 +377,7 @@ SPEC CHECKSUMS:
   appcenter-core: 98c617ae028c90020e404f020c37d7cb189adf4c
   appcenter-crashes: add23a3c3cf0403e1f54c39d85e9b3c5db7279e7
   appcenter-push: 9a88b078ad61718947c92561b5b86da54e185582
-  AppCenterReactNativeShared: d030cbd4c11902dcff4a9cea80dac66714cc2df6
+  AppCenterReactNativeShared: c57d2566896ba19a6193046c8966691c41b4be93
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 5bc5b1606fc9a7ac6956de049f6e30901ed31c49

--- a/TestApp/ios/Podfile.lock
+++ b/TestApp/ios/Podfile.lock
@@ -249,6 +249,8 @@ PODS:
     - React
   - RNGestureHandler (1.5.0):
     - React
+  - RNScreens (2.3.0):
+    - React
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -288,13 +290,14 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
-    - AppCenter
   https://github.com/CocoaPods/Specs.git:
     - boost-for-react-native
+  trunk:
+    - AppCenter
 
 EXTERNAL SOURCES:
   appcenter-analytics:
@@ -363,6 +366,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-fs"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNScreens:
+    :path: "../node_modules/react-native-screens"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -372,7 +377,7 @@ SPEC CHECKSUMS:
   appcenter-core: 98c617ae028c90020e404f020c37d7cb189adf4c
   appcenter-crashes: add23a3c3cf0403e1f54c39d85e9b3c5db7279e7
   appcenter-push: 9a88b078ad61718947c92561b5b86da54e185582
-  AppCenterReactNativeShared: c57d2566896ba19a6193046c8966691c41b4be93
+  AppCenterReactNativeShared: d030cbd4c11902dcff4a9cea80dac66714cc2df6
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 5bc5b1606fc9a7ac6956de049f6e30901ed31c49
@@ -402,6 +407,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 5ae4d57458804e99f73d427214442a6b10a53856
   RNFS: 795866388a01de4e470f3b1041a99cf20a343844
   RNGestureHandler: a4ddde1ffc6e590c8127b8b7eabfdade45475c74
+  RNScreens: 03bf608b92ac0acf323f47d8f5b63a8f829340c8
   Yoga: 02036f6383c0008edb7ef0773a0e6beb6ce82bd1
 
 PODFILE CHECKSUM: 64162dc4bf7d5a1f1b45d18a8143677b2578e20e

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -24,6 +24,7 @@
     "react-native-gesture-handler": "1.5.0",
     "react-native-image-picker": "1.1.0",
     "react-native-modal-selector": "1.1.2",
+    "react-native-screens": "2.3.0",
     "react-navigation": "3.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~~Has `CHANGELOG.md` been updated?~~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

**react-navigation-tabs** package has **react-native-screens** as a [peerDependency](https://flaviocopes.com/npm-peer-dependencies/), which means it is not downloaded automatically when using `npm i`. It used to work because **react-native-screens** was required by **react-navigation/native@3.3.0**
```
"@react-navigation/native": {
"version": "3.3.0",
"resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.3.0.tgz",
...
"requires": {
"hoist-non-react-statics": "^3.0.1",
"react-native-safe-area-view": "^0.13.0",
"react-native-screens": "^1.0.0 || ^1.0.0-alpha"
},
```

But **react-navigation/native@3.6.5** doesn't have an explicit dependency on **react-native-screens** anymore:
```
"@react-navigation/native": {
"version": "3.6.5",
"resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.6.5.tgz",
...
"requires": {
"hoist-non-react-statics": "^3.3.2",
"react-native-safe-area-view": "^0.14.8"
},

```

## Related PRs or issues

[AB#78100](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/78100)