### PR TITLE
Remove TestAppTypescript in a post-clone script

### DIFF
--- a/DemoApp/appcenter-post-clone.sh
+++ b/DemoApp/appcenter-post-clone.sh
@@ -2,7 +2,7 @@
 echo "Executing post clone script in `pwd`"
 echo $NPM_RC | base64 --decode > $APPCENTER_SOURCE_DIRECTORY/DemoApp/.npmrc
 # Delete everything except DemoApp folder
-rm -rf ../appcenter* ../AppCenterReactNativeShared ../TestApp34 ../BrownfieldTestApp ../TestApp
+rm -rf ../appcenter* ../AppCenterReactNativeShared ../TestApp34 ../BrownfieldTestApp ../TestApp ../TestAppTypescript
 
 pod repo add $REPO_NAME https://$USER_ACCOUNT:$ACCESS_TOKEN@$PRIVATE_REPO_BASE_URL/$REPO_NAME
 pod repo update


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~~Has `CHANGELOG.md` been updated?~~
* [ ] ~~Are tests passing locally?~~
* [x] Are the files formatted correctly?
* [ ] ~~Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~~

## Description

Fix an error on AppCenter Build when building DemoApp:
```
##[error]Error: Failed find: ENOENT: no such file or directory, stat 'TestAppTypescript/ios/Pods/Headers/Public/AppCenterReactNativeShared/AppCenterReactNativeShared/AppCenterReactNativeShared.h'
```