### PR TITLE
Fix App Center build

### DIFF
--- a/DemoApp/android/app/build.gradle
+++ b/DemoApp/android/app/build.gradle
@@ -144,7 +144,6 @@ android {
 }
 
 dependencies {
-    implementation project(':react-native-screens')
     implementation project(':react-native-gesture-handler')
     implementation project(':appcenter')
     implementation project(':appcenter-analytics')

--- a/DemoApp/android/app/src/main/java/com/demoapp/MainApplication.java
+++ b/DemoApp/android/app/src/main/java/com/demoapp/MainApplication.java
@@ -7,7 +7,6 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
-import com.swmansion.rnscreens.RNScreensPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -37,7 +36,6 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
             return Arrays.asList(
                     new MainReactPackage(),
-                    new RNScreensPackage(),
                     new RNGestureHandlerPackage(),
                     new ImagePickerPackage(),
                     new RNFSPackage(),

--- a/DemoApp/android/settings.gradle
+++ b/DemoApp/android/settings.gradle
@@ -1,6 +1,4 @@
 rootProject.name = 'DemoApp'
-include ':react-native-screens'
-project(':react-native-screens').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-screens/android')
 include ':react-native-gesture-handler'
 project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
 include ':react-native-image-picker'


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~~Has `CHANGELOG.md` been updated?~~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The build failed because of incompatibility between appcompat and androidx dependencies:
```
    Attribute application@appComponentFactory value=(android.support.v4.app.CoreComponentFactory) from [com.android.support:support-compat:28.0.0] AndroidManifest.xml:22:18-91
    is also present at [androidx.core:core:1.1.0] AndroidManifest.xml:24:18-86 value=(androidx.core.app.CoreComponentFactory).

```

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-react-native/pull/806
