### PR TITLE
Add AppCenterReactNativeShared xcworkspace

### DIFF
--- a/AppCenterReactNativeShared/ios/.gitignore
+++ b/AppCenterReactNativeShared/ios/.gitignore
@@ -1,3 +1,1 @@
 Pods/
-*.xcworkspacedata
-*.xcworkspace

--- a/AppCenterReactNativeShared/ios/AppCenterReactNativeShared.xcodeproj/xcshareddata/xcschemes/AppCenterReactNativeShared.xcscheme
+++ b/AppCenterReactNativeShared/ios/AppCenterReactNativeShared.xcodeproj/xcshareddata/xcschemes/AppCenterReactNativeShared.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5419C2551D81FDA300DDF3A1"
+               BuildableName = "libAppCenterReactNativeShared.a"
+               BlueprintName = "AppCenterReactNativeShared"
+               ReferencedContainer = "container:AppCenterReactNativeShared.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5419C2551D81FDA300DDF3A1"
+            BuildableName = "libAppCenterReactNativeShared.a"
+            BlueprintName = "AppCenterReactNativeShared"
+            ReferencedContainer = "container:AppCenterReactNativeShared.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AppCenterReactNativeShared/ios/AppCenterReactNativeShared.xcworkspace/contents.xcworkspacedata
+++ b/AppCenterReactNativeShared/ios/AppCenterReactNativeShared.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:AppCenterReactNativeShared.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/AppCenterReactNativeShared/ios/AppCenterReactNativeShared.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/AppCenterReactNativeShared/ios/AppCenterReactNativeShared.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/TestApp/update-npm-packages.sh
+++ b/TestApp/update-npm-packages.sh
@@ -28,10 +28,7 @@ pod repo update
 echo "Install shared framework pods..."
 (cd ../AppCenterReactNativeShared/ios && pod install)
 
-echo "Build shared framework..."
-(cd ../AppCenterReactNativeShared/ios && SRCROOT=`pwd` ./build-fat-framework.sh)
-
-echo "Running pod install..."
+echo "Running pod install and building shared framework..."
 (cd ios && pod install)
 
 echo "Copy shared framework pod..."


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~~Has `CHANGELOG.md` been updated?~~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR:
- adds `AppCenterReactNativeShared.xcworkspace` to git as it is required by `build-fat-framework.sh` now.
- removes unused `Fat Framework` target from `AppCenterReactNativeShared` project.
- removes an unnecessary call to `build-fat-framework.sh` in `update-npm-packages`, because it is called during `pod install`

## Related PRs or issues

[AB#84324](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Ivan-Team/Backlog%20Items/?workitem=84324)