### PR TITLE
Add Apple silicon build scripts

### DIFF
--- a/AppCenterReactNativeShared/append-silicon.sh
+++ b/AppCenterReactNativeShared/append-silicon.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
-# This script should be called after build-xcframework succeed under Xcode 11.
 
-# directory with Xcode 11 artifacts
-PRODUCT_DIRECTORY=`pwd`/Products/AppCenterReactNativeShared
-XCODE_11_PRODUCT_DIRECTORY=`pwd`/Products/AppCenterReactNativeShared-xcode11
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Builds arm64 slices under Xcode 12 and appends them to xcramework built under Xcode 11.
+# Usage: export SRCROOT=`pwd` && ./append-silicon.sh
+# Note: This script should be called after build-xcframework succeed under Xcode 11.
+
+set -e
 
 export FMK_NAME=AppCenterReactNativeShared
+PRODUCT_DIRECTORY=`pwd`/Products/AppCenterReactNativeShared
+XCODE_11_PRODUCT_DIRECTORY=`pwd`/Products/AppCenterReactNativeShared-xcode11
 
 if [ ! -d "${PRODUCT_DIRECTORY}" ] || [ -z "$(ls -A $PRODUCT_DIRECTORY)" ]; then
     echo "Directory $PRODUCT_DIRECTORY does not exist or is empty"
     exit 1
 fi
-
 if [ -d "${XCODE_11_PRODUCT_DIRECTORY}" ]; then
     echo "Clean $XCODE_11_PRODUCT_DIRECTORY directory"
     rm -rf "${XCODE_11_PRODUCT_DIRECTORY}"
@@ -45,22 +50,22 @@ append_to_xcframework() {
     "$PRODUCT_DIRECTORY/Release-$2/$FMK_NAME.framework"
 }
 
+echo "Append arm64 slices to binaries built under Xcode 11"
 append_to_xcframework ios-i386_x86_64-simulator iphonesimulator
 append_to_xcframework ios-x86_64-maccatalyst maccatalyst
 
-
 for framework in $XCODE_11_PRODUCT_DIRECTORY/$FMK_NAME.xcframework/*/$FMK_NAME.framework; do
-        xcframeworks+=( -framework "$framework")
-        echo $framework
+  xcframeworks+=( -framework "$framework")
+  echo $framework
 done
 
 echo "Clean product directory for the full xcframework"
 rm -rf "${PRODUCT_DIRECTORY}"
 
+echo "Repackage xcframework with additional architectures"
 xcodebuild -create-xcframework "${xcframeworks[@]}" -output "$PRODUCT_DIRECTORY/$FMK_NAME.xcframework"
 
-# Copies the license file to the products directory (required for cocoapods)
+echo "Copy the license file to the products directory (required for cocoapods)"
 cp -f "$XCODE_11_PRODUCT_DIRECTORY/LICENSE" "$PRODUCT_DIRECTORY"
 
 ls "$PRODUCT_DIRECTORY/$FMK_NAME.xcframework"
-

--- a/AppCenterReactNativeShared/append-silicon.sh
+++ b/AppCenterReactNativeShared/append-silicon.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# This script should be called after build-xcframework succeed under Xcode 11.
+
+# directory with Xcode 11 artifacts
+PRODUCT_DIRECTORY=`pwd`/Products/AppCenterReactNativeShared
+XCODE_11_PRODUCT_DIRECTORY=`pwd`/Products/AppCenterReactNativeShared-xcode11
+
+export FMK_NAME=AppCenterReactNativeShared
+
+if [ ! -d "${PRODUCT_DIRECTORY}" ] || [ -z "$(ls -A $PRODUCT_DIRECTORY)" ]; then
+    echo "Directory $PRODUCT_DIRECTORY does not exist or is empty"
+    exit 1
+fi
+
+if [ -d "${XCODE_11_PRODUCT_DIRECTORY}" ]; then
+    echo "Clean $XCODE_11_PRODUCT_DIRECTORY directory"
+    rm -rf "${XCODE_11_PRODUCT_DIRECTORY}"
+fi
+
+echo "Copy resources built with Xcode 11 to another folder"
+cp -R $PRODUCT_DIRECTORY $XCODE_11_PRODUCT_DIRECTORY
+
+echo "Clean directory for new Xcode build products"
+rm -rf "${PRODUCT_DIRECTORY}"
+
+echo "Build xcframeworks with new Xcode"
+export SRCROOT=`pwd`/ios
+export IOS_PLATFORMS="maccatalyst iphonesimulator"
+
+./ios/build-silicon.sh
+
+append_to_framework() {
+  if [ ! -e "$1" ]; then
+    return 1
+  fi
+  local binary="$1/$FMK_NAME"
+  [[ ! -e "$binary" ]] && binary="$1/$FMK_NAME"
+  lipo "$binary" "$2/$FMK_NAME" -create -output "$binary"
+  lipo -info "$binary"
+}
+
+append_to_xcframework() {
+  append_to_framework \
+    "$XCODE_11_PRODUCT_DIRECTORY/$FMK_NAME.xcframework/$1/$FMK_NAME.framework" \
+    "$PRODUCT_DIRECTORY/Release-$2/$FMK_NAME.framework"
+}
+
+append_to_xcframework ios-i386_x86_64-simulator iphonesimulator
+append_to_xcframework ios-x86_64-maccatalyst maccatalyst
+
+
+for framework in $XCODE_11_PRODUCT_DIRECTORY/$FMK_NAME.xcframework/*/$FMK_NAME.framework; do
+        xcframeworks+=( -framework "$framework")
+        echo $framework
+done
+
+echo "Clean product directory for the full xcframework"
+rm -rf "${PRODUCT_DIRECTORY}"
+
+xcodebuild -create-xcframework "${xcframeworks[@]}" -output "$PRODUCT_DIRECTORY/$FMK_NAME.xcframework"
+
+# Copies the license file to the products directory (required for cocoapods)
+cp -f "$XCODE_11_PRODUCT_DIRECTORY/LICENSE" "$PRODUCT_DIRECTORY"
+
+ls "$PRODUCT_DIRECTORY/$FMK_NAME.xcframework"
+

--- a/AppCenterReactNativeShared/ios/AppCenterReactNativeShared.xcodeproj/project.pbxproj
+++ b/AppCenterReactNativeShared/ios/AppCenterReactNativeShared.xcodeproj/project.pbxproj
@@ -6,20 +6,6 @@
 	objectVersion = 46;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		CB732A521DCBA94900720B25 /* Fat Framework */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = CB732A531DCBA94900720B25 /* Build configuration list for PBXAggregateTarget "Fat Framework" */;
-			buildPhases = (
-				CB732A561DCBA95000720B25 /* ShellScript */,
-			);
-			dependencies = (
-			);
-			name = "Fat Framework";
-			productName = "Fat Framework";
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
 		04DB2A06646C1BB719107C2F /* Pods_AppCenterReactNativeShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DC442297923E7CCD669E385 /* Pods_AppCenterReactNativeShared.framework */; };
 		5419C25A1D81FDA300DDF3A1 /* AppCenterReactNativeShared.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5419C2591D81FDA300DDF3A1 /* AppCenterReactNativeShared.h */; };
@@ -161,11 +147,6 @@
 					5419C2551D81FDA300DDF3A1 = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
-					CB732A521DCBA94900720B25 = {
-						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = UBF8T346G9;
-						ProvisioningStyle = Automatic;
-					};
 				};
 			};
 			buildConfigurationList = 5419C2511D81FDA300DDF3A1 /* Build configuration list for PBXProject "AppCenterReactNativeShared" */;
@@ -182,7 +163,6 @@
 			projectRoot = "";
 			targets = (
 				5419C2551D81FDA300DDF3A1 /* AppCenterReactNativeShared */,
-				CB732A521DCBA94900720B25 /* Fat Framework */,
 			);
 		};
 /* End PBXProject section */
@@ -223,19 +203,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nexport FRAMEWORK_LOCN=\"${BUILT_PRODUCTS_DIR}/AppCenterReactNativeShared.framework\"\n\n# Create the path to the real Headers\nmkdir -p \"${FRAMEWORK_LOCN}/Versions/A/Headers\"\n\n# Create the required symlinks\n/bin/ln -sfh A \"${FRAMEWORK_LOCN}/Versions/Current\"\n/bin/ln -sfh Versions/Current/Headers \"${FRAMEWORK_LOCN}/Headers\"\n/bin/ln -sfh \"Versions/Current/${PRODUCT_NAME}\" \\\n\"${FRAMEWORK_LOCN}/${PRODUCT_NAME}\"\n\n# Copy the public headers into the framework\n/bin/cp -a \"${TARGET_BUILD_DIR}/${PUBLIC_HEADERS_FOLDER_PATH}/\" \\\n\"${FRAMEWORK_LOCN}/Versions/A/Headers\"";
-		};
-		CB732A561DCBA95000720B25 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}\n\n./build-xcframework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -379,24 +346,6 @@
 			};
 			name = Release;
 		};
-		CB732A541DCBA94900720B25 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEVELOPMENT_TEAM = UBF8T346G9;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Debug;
-		};
-		CB732A551DCBA94900720B25 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEVELOPMENT_TEAM = UBF8T346G9;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -414,15 +363,6 @@
 			buildConfigurations = (
 				5419C2601D81FDA300DDF3A1 /* Debug */,
 				5419C2611D81FDA300DDF3A1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CB732A531DCBA94900720B25 /* Build configuration list for PBXAggregateTarget "Fat Framework" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CB732A541DCBA94900720B25 /* Debug */,
-				CB732A551DCBA94900720B25 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AppCenterReactNativeShared/ios/build-framework.sh
+++ b/AppCenterReactNativeShared/ios/build-framework.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Read arguments
+CURRENT_PLATFORM=$1
+BUILD_ARGUMENTS=$2
+
+if [ -z "$CURRENT_PLATFORM" ]; then
+    echo "Build platform argument should be provided"
+    exit 1
+fi
+
+# Open the source directory
+cd $SRCROOT
+    
+# Cleaning previous build
+xcodebuild -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -quiet clean
+
+# Building framework.
+if [ ${CURRENT_PLATFORM} == "maccatalyst" ]; then
+    xcodebuild $BUILD_ARGUMENTS -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -destination 'platform=macOS,variant=Mac Catalyst' -derivedDataPath "$DERIVED_DATA_PATH" -quiet
+else
+    xcodebuild $BUILD_ARGUMENTS -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -sdk "${CURRENT_PLATFORM}" -derivedDataPath "$DERIVED_DATA_PATH" -quiet
+fi
+
+# Creates and renews Release-*platform* temporary framework folder.
+INSTALL_DIR=${TEMP_DIR}/Release-${CURRENT_PLATFORM}
+FMK_DIR=${INSTALL_DIR}/${FMK_NAME}.framework
+
+mkdir -p "${INSTALL_DIR}"
+mkdir -p "${FMK_DIR}"
+
+BINARY_PATH="${WRK_DIR}/Release-${CURRENT_PLATFORM}/lib${FMK_NAME}.a"
+HEADERS_DIR="${WRK_DIR}/Release-${CURRENT_PLATFORM}/include/${FMK_NAME}/"
+MODULEMAP_PATH="${SRCROOT}/${FMK_NAME}/Support/module.modulemap"
+
+mkdir -p "${FMK_DIR}/Headers"
+mkdir -p "${FMK_DIR}/Modules"
+
+# Copy the swift import file to the temporary framework folder.
+cp -f "${MODULEMAP_PATH}" "${FMK_DIR}/Modules/"
+
+# Copies the headers files to the temporary framework folder.
+cp -R "${HEADERS_DIR}/" "${FMK_DIR}/Headers/"
+
+# Copies the static library files to the temporary framework folder.
+cp -R "${BINARY_PATH}" "${FMK_DIR}/${FMK_NAME}"

--- a/AppCenterReactNativeShared/ios/build-framework.sh
+++ b/AppCenterReactNativeShared/ios/build-framework.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Builds a framework for a platform provided in the first argument.
+# Usage: ./build-framework.sh <platform> <xcodebuild arguments>
+
+set -e
+
 # Read arguments
 CURRENT_PLATFORM=$1
 BUILD_ARGUMENTS=$2
@@ -15,14 +23,14 @@ cd $SRCROOT
 # Cleaning previous build
 xcodebuild -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -quiet clean
 
-# Building framework.
+# Building framework
 if [ ${CURRENT_PLATFORM} == "maccatalyst" ]; then
-    xcodebuild $BUILD_ARGUMENTS -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -destination 'platform=macOS,variant=Mac Catalyst' -derivedDataPath "$DERIVED_DATA_PATH" -quiet
+    xcodebuild $BUILD_ARGUMENTS -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -destination 'platform=macOS,variant=Mac Catalyst' -derivedDataPath "$DERIVED_DATA_PATH"
 else
-    xcodebuild $BUILD_ARGUMENTS -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -sdk "${CURRENT_PLATFORM}" -derivedDataPath "$DERIVED_DATA_PATH" -quiet
+    xcodebuild $BUILD_ARGUMENTS -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -sdk "${CURRENT_PLATFORM}" -derivedDataPath "$DERIVED_DATA_PATH"
 fi
 
-# Creates and renews Release-*platform* temporary framework folder.
+# Create and renew Release-*platform* temporary framework folder
 INSTALL_DIR=${TEMP_DIR}/Release-${CURRENT_PLATFORM}
 FMK_DIR=${INSTALL_DIR}/${FMK_NAME}.framework
 

--- a/AppCenterReactNativeShared/ios/build-silicon.sh
+++ b/AppCenterReactNativeShared/ios/build-silicon.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-# Build arm64 slices on CI separately as Xcode 11.3 doesn't build them.
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Builds arm64 slices under Xcode 12 for provided IOS_PLATFORMS argument.
+# Usage: ./build-silicon.sh
+# Note: Requires SRCROOT, IOS_PLATFORMS, FMK_NAME.
+
+set -e
 
 PRODUCTS_DIR=${SRCROOT}/../Products
 ZIP_FOLDER=${FMK_NAME}
@@ -9,14 +17,12 @@ export TEMP_DIR=${PRODUCTS_DIR}/${ZIP_FOLDER}
 export DERIVED_DATA_PATH=build
 export WRK_DIR=${DERIVED_DATA_PATH}/Build/Products
 
-# # Cleaning the oldest.
+# Cleaning the old build
 if [ -d "${TEMP_DIR}" ]; then
 rm -rf "${TEMP_DIR}"
 fi
 
 for sdk in $IOS_PLATFORMS; do
-
-    # Build framework with arguments: $1=current-platform, $2=xcodebuild arguments
     $SRCROOT/build-framework.sh $sdk "ONLY_ACTIVE_ARCH=NO ARCHS=arm64"
 done
 

--- a/AppCenterReactNativeShared/ios/build-silicon.sh
+++ b/AppCenterReactNativeShared/ios/build-silicon.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Build arm64 slices on CI separately as Xcode 11.3 doesn't build them.
+
+PRODUCTS_DIR=${SRCROOT}/../Products
+ZIP_FOLDER=${FMK_NAME}
+export TEMP_DIR=${PRODUCTS_DIR}/${ZIP_FOLDER}
+
+# Working dir will be deleted after the framework creation.
+export DERIVED_DATA_PATH=build
+export WRK_DIR=${DERIVED_DATA_PATH}/Build/Products
+
+# # Cleaning the oldest.
+if [ -d "${TEMP_DIR}" ]; then
+rm -rf "${TEMP_DIR}"
+fi
+
+for sdk in $IOS_PLATFORMS; do
+
+    # Build framework with arguments: $1=current-platform, $2=xcodebuild arguments
+    $SRCROOT/build-framework.sh $sdk "ONLY_ACTIVE_ARCH=NO ARCHS=arm64"
+done
+
+# Remove build folder
+rm -r "${SRCROOT}/${DERIVED_DATA_PATH}"

--- a/AppCenterReactNativeShared/ios/build-xcframework.sh
+++ b/AppCenterReactNativeShared/ios/build-xcframework.sh
@@ -1,76 +1,35 @@
+#!/bin/bash
+
+# Build initial xcframework under Xcode 11.3
+
 # Sets the target folders and the final framework product.
-FMK_NAME=AppCenterReactNativeShared
+export FMK_NAME=AppCenterReactNativeShared
+IOS_PLATFORMS="iphoneos iphonesimulator maccatalyst"
 
 # Install dir will be the final output to the framework.
 # The following line create it in the root folder of the current project.
 PRODUCTS_DIR=${SRCROOT}/../Products
 ZIP_FOLDER=${FMK_NAME}
-TEMP_DIR=${PRODUCTS_DIR}/${ZIP_FOLDER}
+export TEMP_DIR=${PRODUCTS_DIR}/${ZIP_FOLDER}
 
 # Directory of final xcframework
 INSTALL_DIR_XCFRAMEWORK=${TEMP_DIR}/${FMK_NAME}.xcframework
 
 # Working dir will be deleted after the framework creation.
-DERIVED_DATA_PATH=build
-WRK_DIR=${DERIVED_DATA_PATH}/Build/Products
+export DERIVED_DATA_PATH=build
+export WRK_DIR=${DERIVED_DATA_PATH}/Build/Products
 
 # # Cleaning the oldest.
 if [ -d "${TEMP_DIR}" ]; then
 rm -rf "${TEMP_DIR}"
 fi
 
-for sdk in maccatalyst iphoneos iphonesimulator; do
-    # Cleaning previous build
-    xcodebuild -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" clean
+for sdk in $IOS_PLATFORMS; do
+    export INSTALL_DIR=${TEMP_DIR}/Release-${sdk}
+    export FMK_DIR=${INSTALL_DIR}/${FMK_NAME}.framework
 
-    # Building framework.
-    if [ ${sdk} == "maccatalyst" ]; then
-        xcodebuild -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -destination 'platform=macOS,variant=Mac Catalyst' -derivedDataPath "$DERIVED_DATA_PATH"
-    else
-        xcodebuild -workspace "${FMK_NAME}.xcworkspace" -configuration "Release" -scheme "${FMK_NAME}" -sdk "${sdk}" -derivedDataPath "$DERIVED_DATA_PATH"
-    fi
-
-    # Creates and renews Release-iphoneos temporary framework folder.
-    INSTALL_DIR=${TEMP_DIR}/Release-${sdk}
-    FMK_DIR=${INSTALL_DIR}/${FMK_NAME}.framework
-
-    mkdir -p "${INSTALL_DIR}"
-    mkdir -p "${FMK_DIR}"
-
-    BINARY_PATH="${WRK_DIR}/Release-${sdk}/lib${FMK_NAME}.a"
-    HEADERS_DIR="${WRK_DIR}/Release-${sdk}/include/${FMK_NAME}/"
-    MODULEMAP_PATH="${SRCROOT}/${FMK_NAME}/Support/module.modulemap"
-
-    if [ ${sdk} == "maccatalyst" ]; then
-        mkdir -p "${FMK_DIR}/Versions"
-        mkdir -p "${FMK_DIR}/Versions/A/Headers"
-        mkdir "${FMK_DIR}/Versions/A/Modules"
-
-        # Copies the static library files to the temporary framework folder.
-        cp -R "${BINARY_PATH}" "${FMK_DIR}/Versions/A/${FMK_NAME}"
-
-        # Create the required symlinks
-        ln -sfh A "${FMK_DIR}/Versions/Current"
-        ln -sfh "Versions/A/Headers" "${FMK_DIR}/Headers"
-        ln -sfh "Versions/A/Modules" "${FMK_DIR}/Modules"
-        ln -sfh "Versions/A/${FMK_NAME}" "${FMK_DIR}/${FMK_NAME}"
-
-        # Copy the public headers into the framework
-        cp -f "${MODULEMAP_PATH}" "${FMK_DIR}/Versions/A/Modules/"
-        cp -R "${HEADERS_DIR}/" "${FMK_DIR}/Versions/A/Headers/"
-    else
-        mkdir -p "${FMK_DIR}/Headers"
-        mkdir -p "${FMK_DIR}/Modules"
-
-        # Copy the swift import file to the temporary framework folder.
-        cp -f "${MODULEMAP_PATH}" "${FMK_DIR}/Modules/"
-
-        # Copies the headers files to the temporary framework folder.
-        cp -R "${HEADERS_DIR}/" "${FMK_DIR}/Headers/"
-
-        # Copies the static library files to the temporary framework folder.
-        cp -R "${BINARY_PATH}" "${FMK_DIR}/${FMK_NAME}"
-    fi
+    #call subscript
+    $SRCROOT/build-framework.sh $sdk
 
     frameworks+=( -framework "${FMK_DIR}")
 done
@@ -81,10 +40,10 @@ xcodebuild -create-xcframework "${frameworks[@]}" -output "${INSTALL_DIR_XCFRAME
 # Copies the license file to the products directory (required for cocoapods)
 cp -f "../LICENSE" "${TEMP_DIR}"
 
-for sdk in iphoneos iphonesimulator maccatalyst; do
+for sdk in $IOS_PLATFORMS; do
     # Remove temporary install folders
     rm -r ${TEMP_DIR}/Release-${sdk}
 done
 
 # Remove build folder
-rm -r "${DERIVED_DATA_PATH}"
+rm -r "${SRCROOT}/${DERIVED_DATA_PATH}"

--- a/AppCenterReactNativeShared/ios/build-xcframework.sh
+++ b/AppCenterReactNativeShared/ios/build-xcframework.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
-# Build initial xcframework under Xcode 11.3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Builds initial(no arm64 for iphonesimulator and maccatalyst slices) xcframework under Xcode 11.3 or the final xcframework if is used under Xcode 12+.
+# Usage: export SRCROOT=`pwd` && ./build-xcframework.sh
+
+set -e
 
 # Sets the target folders and the final framework product.
 export FMK_NAME=AppCenterReactNativeShared
 IOS_PLATFORMS="iphoneos iphonesimulator maccatalyst"
-
-# Install dir will be the final output to the framework.
-# The following line create it in the root folder of the current project.
 PRODUCTS_DIR=${SRCROOT}/../Products
 ZIP_FOLDER=${FMK_NAME}
 export TEMP_DIR=${PRODUCTS_DIR}/${ZIP_FOLDER}
@@ -28,7 +31,6 @@ for sdk in $IOS_PLATFORMS; do
     export INSTALL_DIR=${TEMP_DIR}/Release-${sdk}
     export FMK_DIR=${INSTALL_DIR}/${FMK_NAME}.framework
 
-    #call subscript
     $SRCROOT/build-framework.sh $sdk
 
     frameworks+=( -framework "${FMK_DIR}")


### PR DESCRIPTION
Add build scripts to build arm64 slices under Xcode 12 and then merge them to xcframework built with Xcode 11.

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~~Has `CHANGELOG.md` been updated?~~
* [ ] ~~Are tests passing locally?~~
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Current CI artifacts are missing arm64 slices.
This PR adds build scripts to create arm64 slices under Xcode 12 and then merge them into an xcframework built with Xcode 11.
Shared code between `build-silicon.sh` and `build-xcframework` is moved into `build-framework.sh`

## Related PRs or issues

[AB#85882](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Ivan-Team/Backlog%20Items/?workitem=85882)
