### PR TITLE
Bump ReactNative version to 0.62.3 for TestApp

### DIFF
--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -18,7 +18,7 @@
     "appcenter-link-scripts": "file:appcenter-link-scripts-4.3.0.tgz",
     "metro": "0.59.0",
     "react": "16.11.0",
-    "react-native": "0.62.2",
+    "react-native": "0.62.3",
     "react-native-fs": "^2.18.0",
     "react-native-gesture-handler": "1.5.0",
     "react-native-image-picker": "1.1.0",


### PR DESCRIPTION
This PR fixes vulnerability issue for ReactNative version 0.62.2. Bumped to 0.62.3

[AB#89455](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/89455)