### PR TITLE
Remove minimist reference from appcenter-link-scripts

### DIFF
--- a/appcenter-link-scripts/package.json
+++ b/appcenter-link-scripts/package.json
@@ -23,8 +23,7 @@
     "mkdirp": "0.5.3",
     "plist": "^3.0.2",
     "which": "1.2.11",
-    "xcode": "2.0.0",
-    "minimist": "1.2.6"
+    "xcode": "2.0.0"
   },
   "devDependencies": {
     "babel-eslint": "7.2.3",


### PR DESCRIPTION

`minimist` package is not used in `appcenter-link-scripts` project directly. It was added to fix vulnerability issue in the past. Now it is not needed, as `mkdirp@0.5.3` is using fixed `minimist@1.2.6`.

Related to the issue #964 and PR #965.
