### PR TITLE
Fix Autolinking for React Native 0.69

### DIFF
--- a/appcenter-analytics/appcenter-analytics.podspec
+++ b/appcenter-analytics/appcenter-analytics.podspec
@@ -1,26 +1,25 @@
 require 'json'
 
-package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+package = JSON.parse(File.read(File.join(__dir__, './package.json')))
 
 Pod::Spec.new do |s|
-  # The name is hardcoded due to a name conflict, resulting in the error 'Errno::ENOENT - No such file or directory @ rb_sysopen - appcenter.podspec.json' error.
-  # See https://github.com/microsoft/appcenter-sdk-react-native/issues/760
-  s.name              = 'appcenter-core'
+  s.name              = package['name']
   s.version           = package['version']
   s.summary           = package['description']
   s.license           = package['license']
   s.homepage          = package['homepage']
   s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/"
 
-  s.author           = { 'Microsoft' => 'appcentersdk@microsoft.com' }
-
+  s.author            = { 'Microsoft' => 'appcentersdk@microsoft.com' }
   s.source            = { :git => "https://github.com/microsoft/appcenter-sdk-react-native.git" }
-  s.source_files      = "AppCenterReactNative/**/*.{h,m}"
+  s.source_files      = "ios/AppCenterReactNativeAnalytics/**/*.{h,m}"
   s.platform          = :ios, '9.0'
   s.requires_arc      = true
 
   s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
+
   s.dependency 'AppCenterReactNativeShared', '~> 4.0'
+  s.dependency 'AppCenter/Analytics', '~> 4.0'
   s.dependency 'React-Core'
   s.static_framework = true
 end

--- a/appcenter-analytics/react-native.config.js
+++ b/appcenter-analytics/react-native.config.js
@@ -3,9 +3,7 @@ const path = require('path');
 module.exports = {
   dependency: {
     platforms: {
-      ios: {
-        podspecPath: path.join(__dirname, 'ios', 'appcenter-analytics.podspec')
-      },
+      ios: {},
       android: {
         packageInstance: 'new AppCenterReactNativeAnalyticsPackage(getApplication(), getResources().getString(R.string.appCenterAnalytics_whenToEnableAnalytics))'
       }

--- a/appcenter-crashes/appcenter-crashes.podspec
+++ b/appcenter-crashes/appcenter-crashes.podspec
@@ -1,6 +1,6 @@
 require 'json'
 
-package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+package = JSON.parse(File.read(File.join(__dir__, './package.json')))
 
 Pod::Spec.new do |s|
   s.name              = package['name']
@@ -11,15 +11,16 @@ Pod::Spec.new do |s|
   s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/"
 
   s.author            = { 'Microsoft' => 'appcentersdk@microsoft.com' }
+
   s.source            = { :git => "https://github.com/microsoft/appcenter-sdk-react-native.git" }
-  s.source_files      = "AppCenterReactNativeAnalytics/**/*.{h,m}"
+  s.source_files      = "ios/AppCenterReactNativeCrashes/**/*.{h,m}"
   s.platform          = :ios, '9.0'
   s.requires_arc      = true
 
   s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
 
   s.dependency 'AppCenterReactNativeShared', '~> 4.0'
-  s.dependency 'AppCenter/Analytics', '~> 4.0'
+  s.dependency 'AppCenter/Crashes', '~> 4.0'
   s.dependency 'React-Core'
   s.static_framework = true
 end

--- a/appcenter-crashes/react-native.config.js
+++ b/appcenter-crashes/react-native.config.js
@@ -3,9 +3,7 @@ const path = require('path');
 module.exports = {
   dependency: {
     platforms: {
-      ios: {
-        podspecPath: path.join(__dirname, 'ios', 'appcenter-crashes.podspec')
-      },
+      ios: {},
       android: {
         packageInstance: 'new AppCenterReactNativeCrashesPackage(getApplication(), getResources().getString(R.string.appCenterCrashes_whenToSendCrashes))'
       }

--- a/appcenter/appcenter-core.podspec
+++ b/appcenter/appcenter-core.podspec
@@ -1,26 +1,26 @@
 require 'json'
 
-package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+package = JSON.parse(File.read(File.join(__dir__, './package.json')))
 
 Pod::Spec.new do |s|
-  s.name              = package['name']
+  # The name is hardcoded due to a name conflict, resulting in the error 'Errno::ENOENT - No such file or directory @ rb_sysopen - appcenter.podspec.json' error.
+  # See https://github.com/microsoft/appcenter-sdk-react-native/issues/760
+  s.name              = 'appcenter-core'
   s.version           = package['version']
   s.summary           = package['description']
   s.license           = package['license']
   s.homepage          = package['homepage']
   s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/"
 
-  s.author            = { 'Microsoft' => 'appcentersdk@microsoft.com' }
+  s.author           = { 'Microsoft' => 'appcentersdk@microsoft.com' }
 
   s.source            = { :git => "https://github.com/microsoft/appcenter-sdk-react-native.git" }
-  s.source_files      = "AppCenterReactNativeCrashes/**/*.{h,m}"
+  s.source_files      = "ios/AppCenterReactNative/**/*.{h,m}"
   s.platform          = :ios, '9.0'
   s.requires_arc      = true
 
   s.vendored_frameworks = 'AppCenterReactNativeShared/AppCenterReactNativeShared.framework'
-
   s.dependency 'AppCenterReactNativeShared', '~> 4.0'
-  s.dependency 'AppCenter/Crashes', '~> 4.0'
   s.dependency 'React-Core'
   s.static_framework = true
 end

--- a/appcenter/react-native.config.js
+++ b/appcenter/react-native.config.js
@@ -3,9 +3,7 @@ const path = require('path');
 module.exports = {
   dependency: {
     platforms: {
-      ios: {
-        podspecPath: path.join(__dirname, 'ios', 'appcenter-core.podspec')
-      },
+      ios: {},
       android: {
         packageInstance: 'new AppCenterReactNativePackage(getApplication())'
       }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Moved podspec location to root directory of project as it is required for autolinking to work in react-native/cli v8
Also removed podspecPath from react-native.config as the parameter is deprecated, making autolink to fail

https://github.com/react-native-community/cli/pull/1537

A few sentences describing the overall goals of the pull request.

## Related PRs or issues

List related PRs and other issues.
#979 

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
