### PR TITLE
[Android] Fix blocking channel if error object is incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 4.4.6 (Under development)
 
+### App Center Crashes
+
+#### Android
+
+* **[Fix]** Fix blocking crashes channel if empty or incomplete error object is passed to `Crashes.trackError`.
+
  ___
  
 ## Version 4.4.5

--- a/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesModule.java
+++ b/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesModule.java
@@ -151,6 +151,7 @@ public class AppCenterReactNativeCrashesModule extends BaseJavaModule {
                 convertedAttachments = AppCenterReactNativeCrashesUtils.toCustomErrorAttachments(attachments);
             }
         } catch (java.lang.Exception ex) {
+            promise.reject("Failed to track error.", ex);
             return;
         }
         String errorReportId = WrapperSdkExceptionManager.trackException(exceptionModel, convertedProperties, convertedAttachments);

--- a/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesUtils.java
+++ b/appcenter-crashes/android/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesUtils.java
@@ -139,9 +139,9 @@ class AppCenterReactNativeCrashesUtils {
                throws java.lang.Exception {
         Exception model = new Exception();
         try {
-            String type = readableMap.getString("type");
-            String message = readableMap.getString("message");
-            String wrapperSdkName = readableMap.getString("wrapperSdkName");
+            String type = readableMap.hasKey("type") ? readableMap.getString("type") : null;
+            String message = readableMap.hasKey("message") ? readableMap.getString("message") : null;
+            String wrapperSdkName = readableMap.hasKey("wrapperSdkName") ? readableMap.getString("wrapperSdkName") : null;
             if (type == null || type == "") {
                 throw new java.lang.Exception("Type value shouldn't be null ot empty");
             }
@@ -154,10 +154,14 @@ class AppCenterReactNativeCrashesUtils {
             model.setWrapperSdkName(wrapperSdkName);
             model.setType(type);
             model.setMessage(message);
-            model.setStackTrace(readableMap.getString("stackTrace"));
+
+            if (readableMap.hasKey("stackTrace")) {
+                model.setStackTrace(readableMap.getString("stackTrace"));
+            }
         } catch (java.lang.Exception e) {
             AppCenterReactNativeCrashesUtils.logError("Failed to get exception model");
             AppCenterReactNativeCrashesUtils.logError(Log.getStackTraceString(e));
+            throw e;
         }
         return model;
     }


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Currently trying to send an empty or incomplete error object via Crashes.trackError ends up with the channel being blocked on Android. Once the crashes channel is blocked, it is impossible to send error logs until the app is relaunched.
The PR fixes this incorrect behaviour.

## Related PRs or issues

[AB#100667](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/100667)