### PR TITLE
Fix crash in TestApp on clicking a modal selector

### DIFF
--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -22,7 +22,7 @@
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "1.5.0",
     "react-native-image-picker": "1.1.0",
-    "react-native-modal-selector": "1.1.2",
+    "react-native-modal-selector": "2.1.2",
     "react-native-screens": "2.3.0",
     "react-navigation": "3.13.0"
   },


### PR DESCRIPTION
## Description

This PR fixes the crash happening on clicking the startup mode list component. The crash is fixed by updating the `react-native-modal-selector`. Assumably, this issue was introduced when we updated react-native version.

## Related PRs or issues

[AB#92500](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/92500)