### PR TITLE
Move namespaces definition to build.gradle file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 5.0.1
 
+#### Android/iOS
+
+* **[Improvement] Move namespace definition from AndroidManifest.xml to build.gradle files.
+___
+
+## Version 5.0.1
+
 ### App Center
 
 * **[Fix]** Fix Regular Expression Denial of Service in debug vulnerability issue (https://github.com/advisories/GHSA-gxpj-cx7g-858c).

--- a/appcenter-analytics/android/build.gradle
+++ b/appcenter-analytics/android/build.gradle
@@ -6,6 +6,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.microsoft.appcenter.reactnative.analytics"
     compileSdkVersion rootProject.properties.get('compileSdkVersion', 29)
     buildToolsVersion rootProject.properties.get('buildToolsVersion', '29.0.2')
 

--- a/appcenter-analytics/android/src/main/AndroidManifest.xml
+++ b/appcenter-analytics/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.microsoft.appcenter.reactnative.analytics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/appcenter-crashes/android/build.gradle
+++ b/appcenter-crashes/android/build.gradle
@@ -6,6 +6,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.microsoft.appcenter.reactnative.crashes"
     compileSdkVersion rootProject.properties.get('compileSdkVersion', 29)
     buildToolsVersion rootProject.properties.get('buildToolsVersion', '29.0.2')
 

--- a/appcenter-crashes/android/src/main/AndroidManifest.xml
+++ b/appcenter-crashes/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.microsoft.appcenter.reactnative.crashes">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/appcenter/android/build.gradle
+++ b/appcenter/android/build.gradle
@@ -6,6 +6,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.microsoft.appcenter.reactnative.appcenter"
     compileSdkVersion rootProject.properties.get('compileSdkVersion', 29)
     buildToolsVersion rootProject.properties.get('buildToolsVersion', '29.0.2')
 

--- a/appcenter/android/src/main/AndroidManifest.xml
+++ b/appcenter/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.microsoft.appcenter.reactnative.appcenter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The namespace declaration in AndroidManifest.xml is currently deprecated. Therefore, following the [recommendation](https://developer.android.com/build/configure-app-module#set-namespace), we moved the namespace declaration to build.gradle file.

## Related PRs or issues

#1033
