### PR TITLE
Fix CodeQL analysis

### DIFF
--- a/.azurepipelines/build-shared-ios-1ES.yml
+++ b/.azurepipelines/build-shared-ios-1ES.yml
@@ -51,6 +51,7 @@ extends:
           sdl:
             codeql:
               language: javascript
+              cadence: 1
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: framework'

--- a/.azurepipelines/build-shared-ios-1ES.yml
+++ b/.azurepipelines/build-shared-ios-1ES.yml
@@ -20,10 +20,10 @@ variables:
 - name: XCODE_PATH
   value: /Applications/Xcode_13.2.1.app/Contents/Developer
 extends:
-  ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
-    template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
-  ${{ else }}:
-    template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  # ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  # ${{ else }}:
+  #   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
       name: Azure Pipelines

--- a/.azurepipelines/build-shared-ios-1ES.yml
+++ b/.azurepipelines/build-shared-ios-1ES.yml
@@ -48,6 +48,9 @@ extends:
         displayName: MacOs
         cancelTimeoutInMinutes: 1
         templateContext:
+          sdl:
+            codeql:
+              language: javascript
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: framework'

--- a/.azurepipelines/build-shared-ios-1ES.yml
+++ b/.azurepipelines/build-shared-ios-1ES.yml
@@ -20,10 +20,10 @@ variables:
 - name: XCODE_PATH
   value: /Applications/Xcode_13.2.1.app/Contents/Developer
 extends:
-  # ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
-  # ${{ else }}:
-  #   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
       name: Azure Pipelines
@@ -51,7 +51,6 @@ extends:
           sdl:
             codeql:
               language: javascript
-              cadence: 1
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: framework'

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -11,10 +11,10 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 extends:
-  ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
-    template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
-  ${{ else }}:
-    template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  # ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  # ${{ else }}:
+  #   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
       name: Azure Pipelines

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -37,6 +37,9 @@ extends:
         displayName: MacOS
         cancelTimeoutInMinutes: 1
         templateContext:
+          sdl:
+            codeql:
+              language: javascript, java
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: Release'

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -11,10 +11,10 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 extends:
-  # ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
-  # ${{ else }}:
-  #   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
       name: Azure Pipelines
@@ -40,7 +40,6 @@ extends:
           sdl:
             codeql:
               language: javascript, java
-              cadence: 1
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: Release'

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -40,6 +40,7 @@ extends:
           sdl:
             codeql:
               language: javascript, java
+              cadence: 1
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish Artifact: Release'


### PR DESCRIPTION
## Description

We explicitly specify the languages to be scanned to avoid scanning errors. In the Publish Maven task, the C++ language is excluded as it is not built, and in the Build shared iOS task, Java is excluded for the same reason. This ensures that only relevant languages are scanned.

[Maven Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1538495&view=results)
[iOS Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1538498&view=results)

## Related PRs or issues

[AB#107387](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/107387)