### PR TITLE
[CI] Add publishing to Azure Maven Artifacts

### DIFF
--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -107,7 +107,7 @@ extends:
               mvn deploy:deploy-file -DgeneratePom=false \
                   -Durl=$(AZURE_REPO) \
                   -Dfile=$ARTIFACT_FILE_BASE.aar \
-                  -Dfiles=$ARTIFACT_FILE_BASE.aar.asc,$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE.pom.asc,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-sources.jar.asc
+                  -Dfiles=$ARTIFACT_FILE_BASE.aar.asc,$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE.pom.asc,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-sources.jar.asc \
                   -DgroupId=com.microsoft.appcenter.reactnative \
                   -DartifactId=$ARTIFACT_ID \
                   -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -69,6 +69,42 @@ extends:
             publishJUnitResults: false
             workingDirectory: './AppCenterReactNativeShared/android'
 
+    - stage: Publish Azure Maven
+      dependsOn: Stage
+      pool:
+        name: macos-latest
+        os: macOS
+      variables:
+        "agent.source.skip": true
+      jobs:
+      - job: Upload package to azure artifacts
+        steps:
+        - task: DownloadPipelineArtifact@2
+          displayName: Download Build Artifacts for APIScan
+          inputs:
+            artifactName: Release
+            targetPath: '$(Agent.BuildDirectory)/Release'
+        - task: Bash@3
+          displayName: Upload files to repository
+          inputs:
+            targetType: 'inline'
+            script: |
+              VERSION=$(grep -E '"version":' appcenter/package.json | awk -F '"' '{print $4}')
+              ARTIFACTS_DIR='$(Agent.BuildDirectory)/Release/appcenter/reactnative/appcenter-react-native/$VERSION'
+              AAR_FILE
+
+              echo "Version: $VERSION"
+              echo "Artifacts dir: $ARTIFACTS_DIR"
+              echo "Commit: $BUILD_SOURCEVERSION"
+              mvn deploy:deploy-file -DgeneratePom=false \
+                  -Durl=$(AZURE_REPO) \
+                  -Dfile=$ARTIFACTS_DIR/appcenter-react-native-$VERSION.aar \
+                  -DgroupId=com.microsoft.appcenter.reactnative \
+                  -DartifactId=appcenter-react-native \
+                  -Dversion=$VERSION-$BUILD_SOURCEVERSION \
+                  -DrepositoryId=AppCenter \
+                  -e
+
     - stage: APIScan
       dependsOn: Stage
       pool:

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -72,7 +72,8 @@ extends:
     - stage: PublishAzureMaven
       dependsOn: Stage
       pool:
-        name: macos-latest
+        name: Azure Pipelines
+        image: macos-latest
         os: macOS
       variables:
         "agent.source.skip": true

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -91,7 +91,7 @@ extends:
             targetType: 'inline'
             script: |
               VERSION=$(basename $(Agent.BuildDirectory)/Release/appcenter/reactnative/appcenter-react-native/*/)
-              ARTIFACTS_DIR='$(Agent.BuildDirectory)/Release/appcenter/reactnative/appcenter-react-native/$VERSION'
+              ARTIFACTS_DIR="$(Agent.BuildDirectory)/Release/appcenter/reactnative/appcenter-react-native/$VERSION"
 
               echo "Version: $VERSION"
               echo "Artifacts dir: $ARTIFACTS_DIR"

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -85,6 +85,10 @@ extends:
           inputs:
             artifactName: Release
             targetPath: '$(Agent.BuildDirectory)/Release'
+        - task: MavenAuthenticate@0
+          displayName: 'Maven Authenticate'
+          inputs:
+            artifactsFeeds: AppCenter
         - task: Bash@3
           displayName: Upload files to repository
           inputs:

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -108,6 +108,7 @@ extends:
                   -Durl=$(AZURE_REPO) \
                   -Dfile=$ARTIFACT_FILE_BASE.aar \
                   -Dfiles=$ARTIFACT_FILE_BASE.aar.asc,$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE.pom.asc,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-sources.jar.asc \
+                  -Dtypes=jar,aar,pom \
                   -DgroupId=com.microsoft.appcenter.reactnative \
                   -DartifactId=$ARTIFACT_ID \
                   -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -70,6 +70,7 @@ extends:
             workingDirectory: './AppCenterReactNativeShared/android'
 
     - stage: PublishAzureMaven
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       dependsOn: Stage
       pool:
         name: Azure Pipelines
@@ -117,6 +118,7 @@ extends:
                   -e
 
     - stage: APIScan
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       dependsOn: Stage
       pool:
         name: 1ES-PT-Windows-2022

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -96,16 +96,21 @@ extends:
             script: |
               VERSION=$(basename $(Agent.BuildDirectory)/Release/appcenter/reactnative/appcenter-react-native/*/)
               ARTIFACTS_DIR="$(Agent.BuildDirectory)/Release/appcenter/reactnative/appcenter-react-native/$VERSION"
+              ARTIFACT_ID="appcenter-react-native"
+              ARTIFACT_FILE_BASE="$ARTIFACTS_DIR/$ARTIFACT_ID-$VERSION"
 
               echo "Version: $VERSION"
               echo "Artifacts dir: $ARTIFACTS_DIR"
               echo "Commit: $BUILD_SOURCEVERSION"
+              echo "ARTIFACT_FILE_BASE: $ARTIFACT_FILE_BASE"
+
               mvn deploy:deploy-file -DgeneratePom=false \
                   -Durl=$(AZURE_REPO) \
-                  -Dfile=$ARTIFACTS_DIR/appcenter-react-native-$VERSION.aar \
+                  -Dfile=$ARTIFACT_FILE_BASE.aar \
+                  -Dfiles=$ARTIFACT_FILE_BASE.aar.asc, $ARTIFACT_FILE_BASE.pom, $ARTIFACT_FILE_BASE.pom.asc, $ARTIFACT_FILE_BASE-sources.jar, $ARTIFACT_FILE_BASE-sources.jar.asc
                   -DgroupId=com.microsoft.appcenter.reactnative \
-                  -DartifactId=appcenter-react-native \
-                  -Dversion=$VERSION-$BUILD_SOURCEVERSION \
+                  -DartifactId=$ARTIFACT_ID \
+                  -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \
                   -DrepositoryId=AppCenter \
                   -e
 

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -90,9 +90,8 @@ extends:
           inputs:
             targetType: 'inline'
             script: |
-              VERSION=$(grep -E '"version":' appcenter/package.json | awk -F '"' '{print $4}')
+              VERSION=$(basename $(Agent.BuildDirectory)/Release/appcenter/reactnative/appcenter-react-native/*/)
               ARTIFACTS_DIR='$(Agent.BuildDirectory)/Release/appcenter/reactnative/appcenter-react-native/$VERSION'
-              AAR_FILE
 
               echo "Version: $VERSION"
               echo "Artifacts dir: $ARTIFACTS_DIR"

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -82,7 +82,7 @@ extends:
       - job: UploadArtifacts
         steps:
         - task: DownloadPipelineArtifact@2
-          displayName: Download Build Artifacts for APIScan
+          displayName: Download Build Artifacts
           inputs:
             artifactName: Release
             targetPath: '$(Agent.BuildDirectory)/Release'
@@ -91,7 +91,7 @@ extends:
           inputs:
             artifactsFeeds: AppCenter
         - task: Bash@3
-          displayName: Upload files to repository
+          displayName: Upload files to Azure Artifacts
           inputs:
             targetType: 'inline'
             script: |

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -77,7 +77,7 @@ extends:
       variables:
         "agent.source.skip": true
       jobs:
-      - job: Upload package to azure artifacts
+      - job: UploadArtifacts
         steps:
         - task: DownloadPipelineArtifact@2
           displayName: Download Build Artifacts for APIScan

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -109,6 +109,7 @@ extends:
                   -Dfile=$ARTIFACT_FILE_BASE.aar \
                   -Dfiles=$ARTIFACT_FILE_BASE.aar.asc,$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE.pom.asc,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-sources.jar.asc \
                   -Dtypes=jar,aar,pom \
+                  -Dclassifiers=sources \
                   -DgroupId=com.microsoft.appcenter.reactnative \
                   -DartifactId=$ARTIFACT_ID \
                   -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -107,7 +107,7 @@ extends:
               mvn deploy:deploy-file -DgeneratePom=false \
                   -Durl=$(AZURE_REPO) \
                   -Dfile=$ARTIFACT_FILE_BASE.aar \
-                  -Dfiles=$ARTIFACT_FILE_BASE.aar.asc, $ARTIFACT_FILE_BASE.pom, $ARTIFACT_FILE_BASE.pom.asc, $ARTIFACT_FILE_BASE-sources.jar, $ARTIFACT_FILE_BASE-sources.jar.asc
+                  -Dfiles=$ARTIFACT_FILE_BASE.aar.asc,$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE.pom.asc,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-sources.jar.asc
                   -DgroupId=com.microsoft.appcenter.reactnative \
                   -DartifactId=$ARTIFACT_ID \
                   -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -100,11 +100,6 @@ extends:
               ARTIFACT_ID="appcenter-react-native"
               ARTIFACT_FILE_BASE="$ARTIFACTS_DIR/$ARTIFACT_ID-$VERSION"
 
-              echo "Version: $VERSION"
-              echo "Artifacts dir: $ARTIFACTS_DIR"
-              echo "Commit: $BUILD_SOURCEVERSION"
-              echo "ARTIFACT_FILE_BASE: $ARTIFACT_FILE_BASE"
-
               mvn deploy:deploy-file -DgeneratePom=false \
                   -Durl=$(AZURE_REPO) \
                   -Dfile=$ARTIFACT_FILE_BASE.aar \

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -107,9 +107,9 @@ extends:
               mvn deploy:deploy-file -DgeneratePom=false \
                   -Durl=$(AZURE_REPO) \
                   -Dfile=$ARTIFACT_FILE_BASE.aar \
-                  -Dfiles=$ARTIFACT_FILE_BASE.aar.asc,$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE.pom.asc,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-sources.jar.asc \
-                  -Dtypes=jar,aar,pom \
-                  -Dclassifiers=sources \
+                  -Dfiles=$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE-sources.jar \
+                  -Dtypes=pom,jar \
+                  -Dclassifiers=pom,sources \
                   -DgroupId=com.microsoft.appcenter.reactnative \
                   -DartifactId=$ARTIFACT_ID \
                   -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -69,7 +69,7 @@ extends:
             publishJUnitResults: false
             workingDirectory: './AppCenterReactNativeShared/android'
 
-    - stage: Publish Azure Maven
+    - stage: PublishAzureMaven
       dependsOn: Stage
       pool:
         name: macos-latest


### PR DESCRIPTION
This PR introduces a new stage in the CI pipeline for publishing artifacts to Azure Maven Artifacts. The artifacts are published with the commit hash included in their version to avoid conflicts during the release process.

[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1541373&view=results)
[AB#104154](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/104154)