### PR TITLE
Bump android SDK versions

### DIFF
--- a/AppCenterReactNativeShared/android/build.gradle
+++ b/AppCenterReactNativeShared/android/build.gradle
@@ -112,7 +112,7 @@ publishing {
 }
 
 dependencies {
-    api 'com.microsoft.appcenter:appcenter:5.0.4'
+    api 'com.microsoft.appcenter:appcenter:5.0.5'
 }
 
 artifacts {

--- a/appcenter-analytics/android/build.gradle
+++ b/appcenter-analytics/android/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    api 'com.microsoft.appcenter:appcenter-analytics:5.0.4'
+    api 'com.microsoft.appcenter:appcenter-analytics:5.0.5'
 
     //api project(':AppCenterReactNativeShared')   // For testing with TestApp
     api 'com.microsoft.appcenter.reactnative:appcenter-react-native:5.0.2'

--- a/appcenter-crashes/android/build.gradle
+++ b/appcenter-crashes/android/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    api 'com.microsoft.appcenter:appcenter-crashes:5.0.4'
+    api 'com.microsoft.appcenter:appcenter-crashes:5.0.5'
 
     //api project(':AppCenterReactNativeShared')   // For testing with TestApp
     api 'com.microsoft.appcenter.reactnative:appcenter-react-native:5.0.2'

--- a/appcenter/android/build.gradle
+++ b/appcenter/android/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    api 'com.microsoft.appcenter:appcenter:5.0.4'
+    api 'com.microsoft.appcenter:appcenter:5.0.5'
 
     //api project(':AppCenterReactNativeShared')   // For testing with TestApp
     api 'com.microsoft.appcenter.reactnative:appcenter-react-native:5.0.2'


### PR DESCRIPTION
Updated android sdk version to 5.0.5

[#AB107442
](https://dev.azure.com/msmobilecenter/Mobile-Center/_boards/board/t/Mobile%20SDK%20team/Backlog%20Items/?workitem=107442)[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1544251&view=results)