### PR TITLE
[TestApp] Replace react-native-fs with react-native-file-access

### DIFF
--- a/TestApp/app/AttachmentsProvider.js
+++ b/TestApp/app/AttachmentsProvider.js
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import RNFS from 'react-native-fs';
 import { ErrorAttachmentLog } from 'appcenter-crashes';
+import { FileSystem, Dirs } from 'react-native-file-access';
 
 const TEXT_ATTACHMENT_KEY = 'TEXT_ATTACHMENT_KEY';
 const BINARY_FILENAME_KEY = 'BINARY_FILENAME_KEY';
@@ -59,15 +59,15 @@ export default class AttachmentsProvider {
   static async saveBinaryAttachment(name, data, type, size) {
     await this.updateItem(BINARY_FILENAME_KEY, name);
     await this.updateItem(BINARY_FILETYPE_KEY, type);
-    await this.updateItem(BINARY_FILESIZE_KEY, size);
+    await this.updateItem(BINARY_FILESIZE_KEY, '' + size);
     await saveFileInDocumentsFolder(data);
   }
 
   static async getBinaryAttachment() {
-    const path = `${RNFS.DocumentDirectoryPath}/${BINARY_ATTACHMENT_STORAGE_FILENAME}`;
+    const path = `${Dirs.DocumentDir}/${BINARY_ATTACHMENT_STORAGE_FILENAME}`;
     let contents = '';
     try {
-      contents = await RNFS.readFile(path, DEFAULT_ENCODING);
+      contents = await FileSystem.readFile(path, DEFAULT_ENCODING);
     } catch (error) {
       console.log(`Error while reading binary attachment file, error: ${error}`);
     }
@@ -98,9 +98,9 @@ export default class AttachmentsProvider {
   }
 
   static async deleteBinaryAttachment() {
-    const path = `${RNFS.DocumentDirectoryPath}/${BINARY_ATTACHMENT_STORAGE_FILENAME}`;
-    if (await RNFS.exists(path)) {
-      await RNFS.unlink(path);
+    const path = `${Dirs.DocumentDir}/${BINARY_ATTACHMENT_STORAGE_FILENAME}`;
+    if (await FileSystem.exists(path)) {
+      await FileSystem.unlink(path);
     }
     await this.updateItem(BINARY_FILENAME_KEY, null);
     await this.updateItem(BINARY_FILETYPE_KEY, null);
@@ -119,8 +119,10 @@ async function getItemFromStorage(key) {
 }
 
 async function saveFileInDocumentsFolder(data) {
-  const path = `${RNFS.DocumentDirectoryPath}/${BINARY_ATTACHMENT_STORAGE_FILENAME}`;
-  RNFS.writeFile(path, data, DEFAULT_ENCODING)
-    .then(() => console.log('Binary attachment saved'))
-    .catch(err => console.error(err.message));
+  const path = `${Dirs.DocumentDir}/${BINARY_ATTACHMENT_STORAGE_FILENAME}`;
+  try {
+    await FileSystem.writeFile(path, data, DEFAULT_ENCODING);
+  } catch (err) {
+    console.error('Cant save binary attachment, ', err.message);
+  }
 }

--- a/TestApp/app/screens/CrashesScreen.js
+++ b/TestApp/app/screens/CrashesScreen.js
@@ -3,7 +3,7 @@
 
 import React, { Component } from 'react';
 import { Image, View, Text, TextInput, Switch, SectionList, TouchableOpacity, NativeModules } from 'react-native';
-import ImagePicker from 'react-native-image-picker';
+import { launchImageLibrary } from 'react-native-image-picker';
 
 import Crashes, { ExceptionModel } from 'appcenter-crashes';
 
@@ -206,16 +206,21 @@ export default class CrashesScreen extends Component {
   }
 
   showFilePicker = () => {
-    const options = { cancelButtonTitle: 'Delete saved image' };
-    ImagePicker.showImagePicker(options, async (response) => {
+    const options = {
+      mediaType: 'photo',
+      includeBase64: true,
+    };
+  
+    launchImageLibrary(options, async (response) => {
       if (response.didCancel) {
         console.log('User cancelled image picker');
         await AttachmentsProvider.deleteBinaryAttachment();
         this.setState({ binaryAttachment: '' });
-      } else if (response.error) {
-        console.log('ImagePicker Error: ', response.error);
+      } else if (response.errorCode) {
+        console.log('ImagePicker Error: ', response.errorMessage);
       } else {
-        await AttachmentsProvider.saveBinaryAttachment(getFileName(response), response.data, getFileType(response), getFileSize(response));
+        const { fileName, base64, type, fileSize } = response.assets[0];
+        await AttachmentsProvider.saveBinaryAttachment(fileName, base64, type, fileSize);
         const binaryAttachmentValue = await AttachmentsProvider.getBinaryAttachmentInfo();
         this.setState({ binaryAttachment: binaryAttachmentValue });
       }

--- a/TestApp/ios/Podfile.lock
+++ b/TestApp/ios/Podfile.lock
@@ -962,11 +962,11 @@ PODS:
   - React-Mapbuffer (0.73.9):
     - glog
     - React-debug
-  - react-native-image-picker (7.1.2):
+  - react-native-image-picker (7.2.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - react-native-safe-area-context (4.14.0):
+  - react-native-safe-area-context (4.14.1):
     - React-Core
   - React-nativeconfig (0.73.9)
   - React-NativeModulesApple (0.73.9):
@@ -1135,17 +1135,19 @@ PODS:
     - React-jsi (= 0.73.9)
     - React-logger (= 0.73.9)
     - React-perflogger (= 0.73.9)
-  - RNCAsyncStorage (2.0.0):
+  - ReactNativeFileAccess (3.1.1):
     - React-Core
-  - RNFS (2.20.0):
+    - ZIPFoundation
+  - RNCAsyncStorage (2.1.0):
     - React-Core
-  - RNScreens (4.0.0):
+  - RNScreens (4.4.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
+  - ZIPFoundation (0.9.19)
 
 DEPENDENCIES:
   - appcenter-analytics (from `../node_modules/appcenter-analytics`)
@@ -1225,8 +1227,8 @@ DEPENDENCIES:
   - React-runtimescheduler (from `../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - ReactNativeFileAccess (from `../node_modules/react-native-file-access`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
-  - RNFS (from `../node_modules/react-native-fs`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -1247,6 +1249,7 @@ SPEC REPOS:
     - libevent
     - OpenSSL-Universal
     - SocketRocket
+    - ZIPFoundation
 
 EXTERNAL SOURCES:
   appcenter-analytics:
@@ -1354,10 +1357,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/utils"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  ReactNativeFileAccess:
+    :path: "../node_modules/react-native-file-access"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
-  RNFS:
-    :path: "../node_modules/react-native-fs"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   Yoga:
@@ -1408,8 +1411,8 @@ SPEC CHECKSUMS:
   React-jsinspector: aee04d04ef553d5e30e52a4de2af958cb060069f
   React-logger: 87a4232dd55485435edfa6803ff0de0b5c9eea1a
   React-Mapbuffer: 6c229dc8f1640457d1f665f0b7d79ab8f604dc8b
-  react-native-image-picker: d3db110a3ded6e48c93aef7e8e51afdde8b16ed0
-  react-native-safe-area-context: 4532f1a0c5d34a46b9324ccaaedcb5582a302b7d
+  react-native-image-picker: 3e4ad7a308e087f49f8aa1443c9ead2e8ce8f060
+  react-native-safe-area-context: 141eca0fd4e4191288dfc8b96a7c7e1c2983447a
   React-nativeconfig: c1729ab95240ec80d47a2bb8354d8f31138e35a7
   React-NativeModulesApple: 115c934a87f3b45fecb0fada08fa70bab3dff65c
   React-perflogger: c93b6a895eca3f9196656bb20ce0e15ad597a4e9
@@ -1430,12 +1433,13 @@ SPEC CHECKSUMS:
   React-runtimescheduler: efb26ad81d94a9b047504bd716b48869bd311649
   React-utils: dab84549e65d6d711937b9c34d9f6d8fb8bd711c
   ReactCommon: 3dc453f427d2f3d7f2c71499d191b456f83c59bd
-  RNCAsyncStorage: d35c79ffba52c1013013e16b1fc295aec2feabb6
-  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNScreens: 6225b1182ac2845b78e7446b0573ea2afb703338
+  ReactNativeFileAccess: 863c8952c05c0ea5f592ef3101169baaf66777bd
+  RNCAsyncStorage: cc6479c4acd84cc7004946946c8afe30b018184d
+  RNScreens: dc2e2add1c0ae719fd469cf106a0aa16c02ec9b5
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 6aaa3c45f0fda0c6929f855121622669dabe1aaf
+  Yoga: 57d2ffe418d024d56f8b0047f335c677e4c4d9ac
+  ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
 PODFILE CHECKSUM: 36123870d60c4a3eb637a6932b6886f03e104d7f
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/TestApp/ios/TestApp/PrivacyInfo.xcprivacy
+++ b/TestApp/ios/TestApp/PrivacyInfo.xcprivacy
@@ -10,6 +10,7 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>C617.1</string>
+				<string>3B52.1</string>
 			</array>
 		</dict>
 		<dict>

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -19,7 +19,7 @@
     "appcenter-link-scripts": "file:appcenter-link-scripts-5.0.3.tgz",
     "react": "18.2.0",
     "react-native": "0.73.9",
-    "react-native-fs": "^2.20.0",
+    "react-native-file-access": "^3.1.1",
     "react-native-image-picker": "^7.1.2",
     "react-native-modal-selector": "^2.1.2",
     "react-native-safe-area-context": "^4.14.0",


### PR DESCRIPTION
`react-native-fs` has a known vulnerability https://github.com/itinance/react-native-fs/issues/1227. Since it is not maintained anymore, I replaced it with `react-native-file-access`.

Additionally, fixed the photo picker library usage.