### PR TITLE
Use java 11 for AppCenterReactNativeShared android build

### DIFF
--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -64,6 +64,12 @@ extends:
             filePath: ./scripts/put-maven-secrets-gradle.sh
             arguments: '"$(MAVEN_USER)" "$(MAVEN_KEY)" "$(GDP_SIGNING_KEY_ID)" "$(Agent.TempDirectory)/appcenter-gpg-key.gpg" "$(GDP_KEY_PASSWORD)"'
             failOnStderr: true
+        - task: JavaToolInstaller@0
+          inputs:
+            versionSpec: '11'
+            jdkArchitectureOption: 'x64'
+            jdkSourceOption: 'PreInstalled'
+          displayName: 'Use Java 11'
         - task: Gradle@1
           displayName: Gradle publish to Maven local
           inputs:


### PR DESCRIPTION
This PR fixes android maven build.

[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1554521&view=results)